### PR TITLE
Use systematic sampling from peaks in priors

### DIFF
--- a/bouquet/cli.py
+++ b/bouquet/cli.py
@@ -2,11 +2,15 @@ import logging
 from argparse import ArgumentParser
 from datetime import datetime
 from pathlib import Path
+
+import numpy as np
 from rdkit import Chem
 
 from bouquet.calculator import CalculatorFactory
 from bouquet.config import (
     DEFAULT_ENERGY_METHOD,
+    DEFAULT_INIT_GRID_BUDGET,
+    DEFAULT_INIT_METHOD,
     DEFAULT_INIT_STEPS,
     DEFAULT_NUM_STEPS,
     DEFAULT_OPTIMIZER_METHOD,
@@ -27,7 +31,7 @@ from bouquet.setup import (
     get_initial_structure,
     get_initial_structure_from_file,
 )
-from bouquet.solver import run_optimization
+from bouquet.solver import plan_initial_points, run_optimization
 
 
 def main():
@@ -69,6 +73,22 @@ def main():
         type=int,
         default=DEFAULT_INIT_STEPS,
         help="Number of initial guesses to make (ignored if --conformer-file is provided)",
+    )
+    parser.add_argument(
+        "--init-method",
+        choices=["random", "peaks"],
+        default=DEFAULT_INIT_METHOD,
+        help="How to generate initial guesses: 'random' (Gaussian around the "
+        "start) or 'peaks' (systematic grid / weighted sampling from the "
+        "dihedral prior peaks). 'peaks' uses built-in priors if --priors is "
+        "not given, and is ignored when --conformer-file is provided.",
+    )
+    parser.add_argument(
+        "--init-grid-budget",
+        type=int,
+        default=DEFAULT_INIT_GRID_BUDGET,
+        help="Maximum systematic peak-grid size for --init-method peaks before "
+        "falling back to weighted sampling of --init-steps points.",
     )
     parser.add_argument(
         "--energy",
@@ -124,6 +144,8 @@ def main():
         optimizer_method=args.optimizer,
         num_steps=args.num_steps,
         init_steps=args.init_steps,
+        init_method=args.init_method,
+        init_grid_budget=args.init_grid_budget,
         auto_steps=args.auto,
         relax=args.relax,
         seed=args.seed,
@@ -176,18 +198,8 @@ def main():
                     f"Conformer {i} has {len(conf)} atoms, expected {len(init_atoms)}"
                 )
 
-    # Compute the number of optimization steps (handles auto mode)
-    initial_count = len(initial_conformers) if initial_conformers else config.init_steps
-    num_steps = config.compute_auto_steps(len(dihedrals), initial_count)
-
-    # Save the initial guess
-    save_structure(out_dir, init_atoms, "initial.xyz")
-
-    # Create calculators using the factory
-    calc = CalculatorFactory.from_config(config, for_optimizer=False, mol=mol)
-    relaxCalc = CalculatorFactory.from_config(config, for_optimizer=True, mol=mol)
-
-    # Create prior module if priors file provided
+    # Create prior module if priors file provided. This drives PiBO acquisition
+    # steering and is only built when --priors is given.
     prior_module = None
     if config.priors_file is not None:
         from bouquet.priors import create_prior_module
@@ -202,6 +214,49 @@ def main():
         logger.info(f"Created prior module from {config.priors_file}")
         logger.info(prior_module.describe())
 
+    # Plan prior-peak initial guesses (opt-in via --init-method peaks).
+    # Conformers take precedence. Peak-seeding is decoupled from PiBO
+    # acquisition: when no --priors file is given we build a built-ins-only
+    # module purely for seeding, leaving acquisition steering off.
+    initial_dihedrals = None
+    if config.init_method == "peaks" and initial_conformers is None:
+        from bouquet.priors import create_prior_module
+
+        planning_module = prior_module
+        if planning_module is None:
+            planning_module = create_prior_module(
+                mol=mol, dihedrals=[d.chain for d in dihedrals]
+            )
+        start_coords = np.array([d.get_angle(init_atoms) for d in dihedrals])
+        initial_dihedrals = plan_initial_points(
+            planning_module,
+            len(dihedrals),
+            start_coords,
+            config.init_steps,
+            config.init_grid_budget,
+            config.seed,
+        )
+        logger.info(
+            f"Planned {len(initial_dihedrals)} prior-peak initial guesses "
+            f"(grid budget {config.init_grid_budget})"
+        )
+
+    # Compute the number of optimization steps (handles auto mode)
+    if initial_conformers:
+        initial_count = len(initial_conformers)
+    elif initial_dihedrals is not None:
+        initial_count = len(initial_dihedrals)
+    else:
+        initial_count = config.init_steps
+    num_steps = config.compute_auto_steps(len(dihedrals), initial_count)
+
+    # Save the initial guess
+    save_structure(out_dir, init_atoms, "initial.xyz")
+
+    # Create calculators using the factory
+    calc = CalculatorFactory.from_config(config, for_optimizer=False, mol=mol)
+    relaxCalc = CalculatorFactory.from_config(config, for_optimizer=True, mol=mol)
+
     result = run_optimization(
         init_atoms,
         dihedrals,
@@ -213,6 +268,7 @@ def main():
         relax=config.relax,
         seed=config.seed,
         initial_conformers=initial_conformers,
+        initial_dihedrals=initial_dihedrals,
         prior_module=prior_module,
         initial_prior_exponent=config.initial_prior_exponent,
         prior_exponent_decay=config.prior_exponent_decay,

--- a/bouquet/cli.py
+++ b/bouquet/cli.py
@@ -242,7 +242,7 @@ def main():
         )
 
     # Compute the number of optimization steps (handles auto mode)
-    if initial_conformers:
+    if initial_conformers is not None:
         initial_count = len(initial_conformers)
     elif initial_dihedrals is not None:
         initial_count = len(initial_dihedrals)

--- a/bouquet/config.py
+++ b/bouquet/config.py
@@ -40,6 +40,12 @@ ACQ_RAW_SAMPLES = 64
 
 # Initial guess sampling
 INITIAL_GUESS_STD = 90
+# How initial guesses are generated: "random" (Gaussian around the start) or
+# "peaks" (systematic grid / weighted sampling from the dihedral prior peaks).
+DEFAULT_INIT_METHOD = "random"
+# Maximum systematic peak-grid size for --init-method peaks before falling back
+# to weighted sampling (e.g. 3 modes x 3 dihedrals = 27 fits; x4 = 81 does not).
+DEFAULT_INIT_GRID_BUDGET = 64
 
 # Prior (PiBO) defaults
 DEFAULT_PRIOR_EXPONENT = 2.0
@@ -94,6 +100,8 @@ class Configuration:
     # Optimization parameters
     num_steps: int = DEFAULT_NUM_STEPS
     init_steps: int = DEFAULT_INIT_STEPS
+    init_method: str = DEFAULT_INIT_METHOD
+    init_grid_budget: int = DEFAULT_INIT_GRID_BUDGET
     auto_steps: bool = False
     relax: bool = True
     seed: int = field(default_factory=lambda: datetime.now().microsecond)

--- a/bouquet/priors.py
+++ b/bouquet/priors.py
@@ -354,6 +354,65 @@ class DihedralPriorModule(nn.Module):
 
         return prob
 
+    def peak_modes(
+        self,
+    ) -> Tuple[
+        List[Tuple[Tuple[int, ...], List[Tuple[Tuple[float, ...], float]]]],
+        List[int],
+    ]:
+        """Per-axis peak locations, for seeding initial points from the prior.
+
+        A univariate dihedral is one axis; a correlated bivariate pair is a
+        single *joint* axis, so taking the product over axes does not break the
+        correlation between the paired dihedrals.
+
+        Returns:
+            ``(axes, uniform_dims)`` where:
+
+            - ``axes`` is a list of ``(dims, candidates)``. ``dims`` is a tuple
+              of dihedral indices (length 1 for a univariate axis, 2 for a
+              bivariate pair). ``candidates`` is a list of
+              ``(values_deg, weight)``: one mode of that axis, with
+              ``values_deg`` aligned to ``dims`` (degrees in [0, 360)) and
+              ``weight`` the normalized mixture weight.
+            - ``uniform_dims`` lists dihedral indices with no angular preference
+              (a uniform prior); callers should leave these to the optimizer.
+        """
+        axes: List[Tuple[Tuple[int, ...], List[Tuple[Tuple[float, ...], float]]]] = []
+        uniform_dims: List[int] = []
+
+        # Univariate axes (one dim each); a None distribution is uniform (no peaks).
+        for d, dist in self.univariate_dists.items():
+            if dist is None:
+                uniform_dims.append(d)
+                continue
+            locs = dist.component_distribution.loc.detach().cpu().numpy()
+            probs = dist.mixture_distribution.probs.detach().cpu().numpy()
+            candidates = [
+                ((float(math.degrees(loc) % 360.0),), float(w))
+                for loc, w in zip(locs, probs)
+            ]
+            axes.append(((d,), candidates))
+
+        # Bivariate axes: a correlated pair is one joint axis of (mu1, mu2) peaks.
+        for (d1, d2), dist in self.bivariate_dists.items():
+            mu1 = dist.mu1.detach().cpu().numpy()
+            mu2 = dist.mu2.detach().cpu().numpy()
+            probs = dist.weights.detach().cpu().numpy()
+            candidates = [
+                (
+                    (
+                        float(math.degrees(m1) % 360.0),
+                        float(math.degrees(m2) % 360.0),
+                    ),
+                    float(w),
+                )
+                for m1, m2, w in zip(mu1, mu2, probs)
+            ]
+            axes.append(((d1, d2), candidates))
+
+        return axes, uniform_dims
+
     def describe(self) -> str:
         """Human-readable description of assignments."""
         lines = [f"DihedralPriorModule (dim={self.dim})"]

--- a/bouquet/solver.py
+++ b/bouquet/solver.py
@@ -1,5 +1,6 @@
 """Methods for solving the conformer option problem"""
 
+import itertools
 import logging
 import warnings
 from dataclasses import dataclass, field
@@ -274,6 +275,93 @@ def _setup_initial_state(
     return state
 
 
+def plan_initial_points(
+    prior_module: DihedralPriorModule,
+    n_dihedrals: int,
+    start_coords: np.ndarray,
+    init_steps: int,
+    grid_budget: int,
+    seed: int,
+) -> np.ndarray:
+    """Plan initial dihedral guesses from the peaks of a dihedral prior.
+
+    Builds either a systematic grid over the prior's peaks (when the full
+    Cartesian product of per-axis modes fits within ``grid_budget``) or a
+    weighted random sample from those peaks (when it does not, or when
+    ``init_steps`` points are wanted from a large space). Dihedrals with a
+    uniform prior carry their starting-geometry angle in the systematic grid
+    (the start geometry comes from ETKDG or supplied conformers, so it is
+    physically realistic) and are drawn uniformly at random when sampling.
+
+    Args:
+        prior_module: Prior whose peaks seed the guesses (see ``peak_modes``).
+        n_dihedrals: Number of dihedral dimensions.
+        start_coords: Starting dihedral angles (degrees), used to fill
+            uniform-prior dimensions in the systematic grid.
+        init_steps: Number of guesses to draw when sampling.
+        grid_budget: Maximum systematic grid size before falling back to
+            sampling.
+        seed: Random seed for the sampling fallback.
+
+    Returns:
+        Array of shape ``(n_points, n_dihedrals)`` in degrees [0, 360).
+    """
+    axes, uniform_dims = prior_module.peak_modes()
+    start_coords = np.asarray(start_coords, dtype=float)
+    rng = np.random.default_rng(seed)
+
+    grid_size = 1
+    for _dims, candidates in axes:
+        grid_size *= len(candidates)
+
+    # Systematic grid over every peak combination (uniform dims keep their
+    # start angle, so the only variation there comes from the optimizer).
+    if axes and grid_size <= grid_budget:
+        points = []
+        candidate_lists = [candidates for _dims, candidates in axes]
+        for combo in itertools.product(*candidate_lists):
+            pt = start_coords.copy()
+            for (dims, _c), (values, _w) in zip(axes, combo):
+                for dim, val in zip(dims, values):
+                    pt[dim] = val
+            points.append(pt % 360.0)
+        return np.array(points)
+
+    # Weighted sampling from the peaks. With no peaked axes at all this degrades
+    # to uniform-random guesses, so "peaks" still yields a spread of points.
+    axis_weights = [
+        np.array([w for _v, w in candidates], dtype=float)
+        for _dims, candidates in axes
+    ]
+    axis_weights = [w / w.sum() for w in axis_weights]
+
+    points = []
+    seen = set()
+    max_attempts = max(20 * init_steps, 100)
+    for _ in range(max_attempts):
+        if len(points) >= init_steps:
+            break
+        pt = start_coords.copy()
+        for d in uniform_dims:
+            pt[d] = rng.uniform(0.0, 360.0)
+        for (dims, candidates), weights in zip(axes, axis_weights):
+            values, _w = candidates[rng.choice(len(candidates), p=weights)]
+            for dim, val in zip(dims, values):
+                pt[dim] = val
+        pt = pt % 360.0
+        # Dedup on rounded coordinates: independent draws collide when peaks are
+        # few, but distinct uniform-dim values keep otherwise-equal points apart.
+        key = tuple(np.round(pt, 3))
+        if key in seen:
+            continue
+        seen.add(key)
+        points.append(pt)
+
+    if not points:
+        return np.empty((0, n_dihedrals))
+    return np.array(points)
+
+
 def _evaluate_initial_guesses(
     state: OptimizationState,
     dihedrals: List[DihedralInfo],
@@ -283,10 +371,12 @@ def _evaluate_initial_guesses(
     init_steps: int,
     seed: int,
     initial_conformers: Optional[List[Atoms]],
+    initial_dihedrals: Optional[np.ndarray] = None,
 ) -> None:
     """Evaluate initial guesses and update state in-place.
 
-    Uses provided conformers if available, otherwise generates random guesses.
+    Precedence: provided conformers, then prior-peak guesses
+    (``initial_dihedrals``), then random Gaussian guesses around the start.
 
     Args:
         state: Optimization state to update
@@ -294,9 +384,11 @@ def _evaluate_initial_guesses(
         calc: Calculator for energy evaluation
         relaxCalc: Calculator used for geometry relaxation
         relax: Whether to relax non-dihedral degrees of freedom
-        init_steps: Number of random guesses if no conformers provided
+        init_steps: Number of random guesses if no conformers/peaks provided
         seed: Random seed for random sampling
         initial_conformers: Optional list of conformer structures
+        initial_dihedrals: Optional array of dihedral guesses (degrees),
+            shape (n_points, n_dihedrals), e.g. from ``plan_initial_points``
     """
     if initial_conformers is not None:
         state.init_steps = len(initial_conformers)
@@ -309,6 +401,25 @@ def _evaluate_initial_guesses(
             rel_energy = energy - state.start_energy
             logger.info(
                 f"Evaluated conformer {i+1: >3}/{len(initial_conformers)}. Energy-E0: {rel_energy:12.6f}"
+            )
+
+            state.append_observation(guess, rel_energy, cur_atoms)
+
+            if state.add_entry is not None:
+                state.add_entry(guess, cur_atoms, energy)
+    elif initial_dihedrals is not None:
+        state.init_steps = len(initial_dihedrals)
+        logger.info(
+            f"Using {state.init_steps} prior-peak initial guesses"
+        )
+        for i, guess in enumerate(initial_dihedrals):
+            guess = np.asarray(guess, dtype=float) % 360.0
+            energy, cur_atoms = evaluate_energy(
+                guess, state.start_atoms, dihedrals, calc, relaxCalc, relax
+            )
+            rel_energy = energy - state.start_energy
+            logger.info(
+                f"Evaluated peak guess {i+1: >3}/{len(initial_dihedrals)}. Energy-E0: {rel_energy:12.6f}"
             )
 
             state.append_observation(guess, rel_energy, cur_atoms)
@@ -673,6 +784,7 @@ def run_optimization(
     relax: bool = True,
     seed: int = 0,
     initial_conformers: Optional[List[Atoms]] = None,
+    initial_dihedrals: Optional[np.ndarray] = None,
     # New PiBO parameters
     prior_module: Optional[DihedralPriorModule] = None,
     initial_prior_exponent: float = 2.0,
@@ -693,6 +805,9 @@ def run_optimization(
         seed: Random seed to use for initial sampling
         initial_conformers: Optional list of conformer structures to use as initial guesses
                            instead of random sampling
+        initial_dihedrals: Optional array of dihedral guesses (degrees) to use as
+                           initial points (e.g. from plan_initial_points). Used
+                           when no conformers are provided; falls back to random.
         return_ensemble: If True, also select and tightly optimize a Boltzmann
             ensemble of low-energy conformers and return it alongside the best
             structure.
@@ -712,9 +827,10 @@ def run_optimization(
     state.prior_exponent = initial_prior_exponent
     state.prior_decay = prior_exponent_decay
 
-    # Evaluate initial guesses (conformers or random)
+    # Evaluate initial guesses (conformers, prior peaks, or random)
     _evaluate_initial_guesses(
-        state, dihedrals, calc, relaxCalc, relax, init_steps, seed, initial_conformers
+        state, dihedrals, calc, relaxCalc, relax, init_steps, seed,
+        initial_conformers, initial_dihedrals,
     )
 
     # Run Bayesian optimization loop


### PR DESCRIPTION
For small molecules (eg up to 4 dihedrals) exhaustive For larger, used as initial points instead of random

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **New Features**
  * Added `--init-method` CLI option to select initial guess generation strategy: `random` or `peaks`-based seeding.
  * Added `--init-grid-budget` CLI option to control initial guess search scope.
  * Peak-based initialization leverages prior knowledge to seed optimization with smarter conformer guesses.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->