### PR TITLE
Add support for faster gradient-boosted BO

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,6 +1,10 @@
 __pycache__
 gfnff_*
 solutions/*
+# build artifacts
+dist/
+build/
+*.egg-info/
 # pixi environments
 .pixi/*
 !.pixi/config.toml

--- a/bouquet/__init__.py
+++ b/bouquet/__init__.py
@@ -1,3 +1,17 @@
 """Utilities for conformer optimization"""
 
+# Defer the heavy scientific stack (torch, botorch, gpytorch, rdkit, ase,
+# networkx) pulled in transitively by these submodules: `import bouquet` stays
+# cheap and each submodule loads only when first accessed (Python 3.15+).
+__lazy_modules__ = [
+    "bouquet.assess",
+    "bouquet.calculator",
+    "bouquet.config",
+    "bouquet.gradients",
+    "bouquet.io",
+    "bouquet.priors",
+    "bouquet.setup",
+    "bouquet.solver",
+]
+
 from . import assess, calculator, config, gradients, io, priors, setup, solver

--- a/bouquet/assess.py
+++ b/bouquet/assess.py
@@ -1,5 +1,19 @@
 """Tools for computing the energy of a molecule"""
 
+from __future__ import annotations
+
+# Annotations are strings (PEP 563), so numpy/ase types in signatures no longer
+# pin those modules at import; defer them and the optimizer submodules until an
+# energy is actually evaluated (Python 3.15+).
+__lazy_modules__ = [
+    "numpy",
+    "ase",
+    "ase.calculators.calculator",
+    "ase.constraints",
+    "ase.optimize",
+    "bouquet.gradients",
+]
+
 import os
 from typing import List, Optional, Tuple, Union
 
@@ -20,14 +34,14 @@ from bouquet.setup import DihedralInfo
 
 
 def evaluate_energy(
-    angles: Union[List[float], np.ndarray],
+    angles: list[float] | np.ndarray,
     atoms: Atoms,
-    dihedrals: List[DihedralInfo],
+    dihedrals: list[DihedralInfo],
     calc: Calculator,
     relaxCalc: Calculator,
     relax: bool = True,
-    steps: Optional[int] = DEFAULT_RELAXATION_STEPS,
-) -> Tuple[float, Atoms]:
+    steps: int | None = DEFAULT_RELAXATION_STEPS,
+) -> tuple[float, Atoms]:
     """
     Compute the potential energy for a set of dihedral angles and optionally relax non-dihedral degrees of freedom.
 
@@ -75,7 +89,7 @@ def evaluate_energy(
     return relax_structure(atoms, calc, relaxCalc, steps)
 
 
-def relax_structure(atoms: Atoms, energyCalc: Calculator, calc: Calculator, steps: Optional[int]) -> Tuple[float, Atoms]:
+def relax_structure(atoms: Atoms, energyCalc: Calculator, calc: Calculator, steps: int | None) -> tuple[float, Atoms]:
     """
     Relax the atomic geometry using the provided optimizer and evaluate its potential energy.
 
@@ -122,15 +136,15 @@ def relax_structure(atoms: Atoms, energyCalc: Calculator, calc: Calculator, step
 
 
 def evaluate_energy_with_gradient(
-    angles: Union[List[float], np.ndarray],
+    angles: list[float] | np.ndarray,
     atoms: Atoms,
-    dihedrals: List[DihedralInfo],
+    dihedrals: list[DihedralInfo],
     calc: Calculator,
     relaxCalc: Calculator,
     relax: bool = True,
-    steps: Optional[int] = DEFAULT_RELAXATION_STEPS,
+    steps: int | None = DEFAULT_RELAXATION_STEPS,
     per_degree: bool = False,
-) -> Tuple[float, Atoms, np.ndarray]:
+) -> tuple[float, Atoms, np.ndarray]:
     """Evaluate the energy and its gradient with respect to the torsion angles.
 
     Thin wrapper around :func:`evaluate_energy` that additionally returns

--- a/bouquet/calc_rdkit.py
+++ b/bouquet/calc_rdkit.py
@@ -1,5 +1,15 @@
 """RDKit force field calculators compatible with ASE interface."""
 
+from __future__ import annotations
+
+# rdkit/numpy are only touched inside method bodies once annotations are strings
+# (the ASE Calculator base class still loads eagerly). Python 3.15+.
+__lazy_modules__ = [
+    "numpy",
+    "rdkit",
+    "rdkit.Chem",
+]
+
 from abc import ABC, abstractmethod
 from typing import List
 
@@ -66,7 +76,7 @@ class RDKitCalculator(Calculator, ABC):
     def calculate(
         self,
         atoms=None,
-        properties: List[str] = None,
+        properties: list[str] = None,
         system_changes=all_changes,
     ):
         """Calculate energy (and optionally forces) using the force field.

--- a/bouquet/cli.py
+++ b/bouquet/cli.py
@@ -118,6 +118,37 @@ def main():
         "GP, so each energy evaluation also contributes a gradient observation.",
     )
     parser.add_argument(
+        "--gradient-steps",
+        type=int,
+        default=0,
+        help="With --use-gradients, use the gradient-enhanced GP only for the "
+        "first N BO steps, then switch to the value-only GP. The gradient GP's "
+        "per-step cost grows steeply with the observation count, so this caps it "
+        "on large/flexible molecules while keeping the early-search benefit. "
+        "0 (default) keeps gradients for the whole run.",
+    )
+    parser.add_argument(
+        "--grad-refit-dense-until",
+        type=int,
+        default=20,
+        help="Gradient-GP refit schedule ('gradfreeze'): do a full hyperparameter "
+        "fit for the first N BO steps, then FREEZE the hyperparameters and only "
+        "re-condition (one Cholesky/step instead of ~200). Refitting is the dominant "
+        "gradient-GP cost and grows with observation count, so freezing keeps the "
+        "full-gradient run affordable on large molecules. Default 20 (validated "
+        "quality-neutral vs full refitting, 5-11 dihedrals); set 0 to refit every "
+        "step (the slow reference).",
+    )
+    parser.add_argument(
+        "--grad-refit-every",
+        type=int,
+        default=0,
+        help="After the dense phase, optionally cold-refresh the frozen "
+        "hyperparameters every Nth BO step (0 freezes for the rest of the run; the "
+        "refresh is a cold fit -- warm-starting drifts the hyperparameters and "
+        "degrades the search). 0 (default); with no dense phase, fits every step.",
+    )
+    parser.add_argument(
         "--priors",
         type=str,
         help="JSON file with dihedral prior definitions",
@@ -173,6 +204,9 @@ def main():
         auto_steps=args.auto,
         relax=args.relax,
         use_gradients=args.use_gradients,
+        gradient_steps=args.gradient_steps,
+        grad_refit_dense_until=args.grad_refit_dense_until,
+        grad_refit_every=args.grad_refit_every,
         seed=args.seed,
         priors_file=Path(args.priors) if args.priors else None,
         initial_prior_exponent=args.prior_exponent,
@@ -342,6 +376,9 @@ def main():
         prior_exponent_decay=config.prior_exponent_decay,
         return_ensemble=config.ensemble,
         use_gradients=config.use_gradients,
+        gradient_steps=config.gradient_steps,
+        grad_refit_dense_until=config.grad_refit_dense_until,
+        grad_refit_every=config.grad_refit_every,
     )
 
     if config.ensemble:

--- a/bouquet/config.py
+++ b/bouquet/config.py
@@ -127,6 +127,20 @@ class Configuration:
     # Use the gradient-enhanced periodic GP surrogate: record dE/dtheta at each
     # evaluation and feed it to the acquisition GP (see GradientEnhancedPeriodicGP).
     use_gradients: bool = False
+    # Cap on the number of leading BO steps that use the gradient-enhanced GP; the
+    # remaining steps use the value-only GP. The gradient GP's per-step cost grows
+    # steeply with observation count, so this bounds it on large molecules while
+    # keeping the early benefit. <=0 keeps gradients for the whole run.
+    gradient_steps: int = 0
+    # Gradient-GP hyperparameter refit schedule (see solver._run_optimization_loop):
+    # cold full fits for the first `grad_refit_dense_until` BO steps, then freeze the
+    # hyperparameters and only re-condition; `grad_refit_every` > 0 cold-refreshes
+    # them every that many post-dense steps. Default (20, 0) = the "gradfreeze"
+    # schedule: cold-fit 20 steps then freeze (validated quality-neutral vs full
+    # refitting across 5-11 dihedrals). Set grad_refit_dense_until=0 to refit every
+    # step (the slow reference).
+    grad_refit_dense_until: int = 20
+    grad_refit_every: int = 0
     seed: int = field(default_factory=lambda: datetime.now().microsecond)
 
     # Prior settings

--- a/bouquet/io.py
+++ b/bouquet/io.py
@@ -1,5 +1,15 @@
 """Input/Output and logging utilities for Bouquet"""
 
+from __future__ import annotations
+
+# ase is only needed when structures are actually written; defer it (and the xyz
+# writer) so importing this module for logging setup alone stays cheap. 3.15+.
+__lazy_modules__ = [
+    "ase",
+    "ase.io.xyz",
+    "json",
+]
+
 import hashlib
 import json
 import logging
@@ -96,7 +106,7 @@ def atoms_to_xyz_string(atoms: Atoms) -> str:
     return xyz.getvalue()
 
 
-def initialize_structure_log(out_dir: Path) -> Tuple[Path, Path]:
+def initialize_structure_log(out_dir: Path) -> tuple[Path, Path]:
     """Initialize the structure logging files.
 
     Creates the CSV log file with headers and returns paths for logging.
@@ -150,7 +160,7 @@ def create_structure_logger(
 
 
 def save_ensemble(
-    out_dir: Path, ensemble: List[Tuple[Atoms, float, float]]
+    out_dir: Path, ensemble: list[tuple[Atoms, float, float]]
 ) -> None:
     """Write the final Boltzmann ensemble to disk.
 

--- a/bouquet/setup.py
+++ b/bouquet/setup.py
@@ -1,12 +1,23 @@
 """Tools for assessing the bond structure of a molecule and finding the dihedrals to move"""
 
+from __future__ import annotations
+
+# With annotations as strings, networkx/ase/rdkit are only used inside function
+# bodies, so defer them until a structure is actually parsed (Python 3.15+).
+__lazy_modules__ = [
+    "networkx",
+    "ase",
+    "ase.io",
+    "rdkit",
+    "rdkit.Chem",
+]
+
 import logging
 from dataclasses import dataclass
 from pathlib import Path
 from typing import List, Optional, Set, Tuple, Union
 
 import networkx as nx
-import numpy as np
 from ase import Atoms
 from ase.io import read
 from rdkit import Chem
@@ -42,7 +53,7 @@ def mol_to_ase_atoms(mol: Chem.Mol, conf_id: int = -1) -> Atoms:
     return atoms
 
 
-def get_initial_structure(smiles: str) -> Tuple[Atoms, Chem.Mol]:
+def get_initial_structure(smiles: str) -> tuple[Atoms, Chem.Mol]:
     """Generate an initial guess for a molecular structure from SMILES.
 
     Args:
@@ -84,7 +95,7 @@ def get_initial_structure(smiles: str) -> Tuple[Atoms, Chem.Mol]:
     return atoms, mol
 
 
-def get_initial_structure_from_file(filename: str) -> Tuple[Atoms, Chem.Mol]:
+def get_initial_structure_from_file(filename: str) -> tuple[Atoms, Chem.Mol]:
     """Generate an initial molecular structure from a file.
 
     Supported formats: .xyz, .mol, .sdf, .mol2, .pdb
@@ -168,7 +179,7 @@ def get_initial_structure_from_file(filename: str) -> Tuple[Atoms, Chem.Mol]:
     return atoms, mol
 
 
-def get_conformers_from_file(filename: str) -> List[Atoms]:
+def get_conformers_from_file(filename: str) -> list[Atoms]:
     """Read multiple conformers from a file.
 
     Args:
@@ -226,15 +237,15 @@ def get_conformers_from_file(filename: str) -> List[Atoms]:
 class DihedralInfo:
     """Describes a dihedral angle within a molecule."""
 
-    chain: Tuple[int, int, int, int] = None
+    chain: tuple[int, int, int, int] = None
     """Atoms that form the dihedral. ASE rotates the last atom when setting a dihedral angle"""
-    group: Set[int] = None
+    group: set[int] = None
     """List of atoms that should rotate along with this dihedral"""
     type: str = None
     """Optional classification of the dihedral (e.g., 'backbone', 'sidechain')"""
-    prior_type: Union[str, int, None] = None
+    prior_type: str | int | None = None
     """Prior type ID for PiBO (assigned by SMARTS matching)"""
-    correlated_with: Optional[int] = None
+    correlated_with: int | None = None
     """Index of correlated dihedral (for bivariate priors)"""
 
     def get_angle(self, atoms: Atoms) -> float:
@@ -284,8 +295,8 @@ def get_bonding_graph(mol: Chem.Mol) -> nx.Graph:
 
 
 def get_dihedral_info(
-    graph: nx.Graph, bond: Tuple[int, int], backbone_atoms: Set[int]
-) -> Optional[DihedralInfo]:
+    graph: nx.Graph, bond: tuple[int, int], backbone_atoms: set[int]
+) -> DihedralInfo | None:
     """For a rotatable bond, get the atoms defining the dihedral and the rotating group.
 
     Args:
@@ -340,7 +351,7 @@ def get_dihedral_info(
         return DihedralInfo(chain=tuple(points), group=b, type="backbone")
 
 
-def detect_dihedrals(mol: Chem.Mol) -> List[DihedralInfo]:
+def detect_dihedrals(mol: Chem.Mol) -> list[DihedralInfo]:
     """Detect the bonds to be treated as rotors.
 
     Uses the RDKit definition of rotatable bonds:

--- a/bouquet/solver.py
+++ b/bouquet/solver.py
@@ -1,5 +1,27 @@
 """Methods for solving the conformer option problem"""
 
+from __future__ import annotations
+
+# With annotations evaluated as strings (PEP 563), the heavy numeric/BO stack is
+# only touched inside function bodies, so defer it until an optimization actually
+# runs. This is the dominant `import bouquet` cost (Python 3.15+).
+__lazy_modules__ = [
+    "numpy",
+    "torch",
+    "ase",
+    "ase.build",
+    "ase.calculators.calculator",
+    "botorch.acquisition.analytic",
+    "botorch.acquisition.prior_guided",
+    "botorch.optim.fit",
+    "botorch.optim",
+    "botorch.models",
+    "botorch.models.transforms.outcome",
+    "gpytorch",
+    "gpytorch.mlls",
+    "gpytorch.priors",
+]
+
 import itertools
 import logging
 import math
@@ -94,12 +116,12 @@ class OptimizationState:
     # NaN where the gradient is unavailable (failed eval, or use_gradients off).
     observed_gradients: torch.Tensor = None  # Shape: (n_observations, n_dihedrals)
     # Per-observation Atoms, aligned index-for-index with the tensors above.
-    observed_atoms: List[Atoms] = field(default_factory=list)
+    observed_atoms: list[Atoms] = field(default_factory=list)
     device: torch.device = field(default_factory=_get_device)
     init_steps: int = 0
-    best_atoms: Optional[Atoms] = None
+    best_atoms: Atoms | None = None
     best_step: int = 0
-    add_entry: Optional[Callable] = None
+    add_entry: Callable | None = None
     # When True, evaluations also record dE/dtheta and the acquisition GP uses
     # the gradient-enhanced surrogate (see GradientEnhancedPeriodicGP).
     use_gradients: bool = False
@@ -120,10 +142,10 @@ class OptimizationState:
     # on condition-only steps).
     grad_refit_dense_until: int = 20
     grad_refit_every: int = 0
-    grad_gp_hypers: Optional[dict] = None
+    grad_gp_hypers: dict | None = None
 
     # PiBO fields
-    prior_module: Optional[DihedralPriorModule] = None
+    prior_module: DihedralPriorModule | None = None
     prior_exponent: float = 2.0
     prior_decay: float = 0.9
 
@@ -132,7 +154,7 @@ class OptimizationState:
         coords: np.ndarray,
         energy: float,
         atoms: Atoms,
-        gradient: Optional[np.ndarray] = None,
+        gradient: np.ndarray | None = None,
     ) -> None:
         """Append a new observation, keeping observed_atoms index-aligned.
 
@@ -185,7 +207,7 @@ def _fit_gradient_gp(
     energy_cap: torch.Tensor,
     observed_gradients: torch.Tensor,
     y_std: torch.Tensor,
-    frozen_hypers: Optional[dict] = None,
+    frozen_hypers: dict | None = None,
 ) -> GradientEnhancedPeriodicGP:
     """Build and fit the gradient-enhanced periodic GP on standardized data.
 
@@ -236,12 +258,12 @@ def _fit_gradient_gp(
 def _select_next_points_botorch(
     train_X: torch.Tensor,
     train_y: torch.Tensor,
-    prior_module: Optional[DihedralPriorModule] = None,
+    prior_module: DihedralPriorModule | None = None,
     prior_exponent: float = 0.0,
-    observed_gradients: Optional[torch.Tensor] = None,
+    observed_gradients: torch.Tensor | None = None,
     use_gradients: bool = False,
-    gp_frozen_hypers: Optional[dict] = None,
-    gp_hyper_out: Optional[dict] = None,
+    gp_frozen_hypers: dict | None = None,
+    gp_hyper_out: dict | None = None,
 ) -> np.ndarray:
     """
     Selects the next dihedral coordinate to evaluate by fitting a Gaussian process to the observed data and optimizing a BOTorch acquisition function.
@@ -356,11 +378,11 @@ def _select_next_points_botorch(
 
 def _setup_initial_state(
     atoms: Atoms,
-    dihedrals: List[DihedralInfo],
+    dihedrals: list[DihedralInfo],
     calc: Calculator,
     relaxCalc: Calculator,
     relax: bool,
-    out_dir: Optional[Path],
+    out_dir: Path | None,
     use_gradients: bool = False,
 ) -> OptimizationState:
     """Perform initial relaxation, evaluate starting point, and set up logging.
@@ -443,7 +465,7 @@ def plan_initial_points(
     init_steps: int,
     grid_budget: int,
     seed: int,
-    max_points: Optional[int] = None,
+    max_points: int | None = None,
 ) -> np.ndarray:
     """Plan initial dihedral guesses from the peaks of a dihedral prior.
 
@@ -547,11 +569,11 @@ def plan_initial_points(
 def _evaluate_point(
     state: OptimizationState,
     guess: np.ndarray,
-    dihedrals: List[DihedralInfo],
+    dihedrals: list[DihedralInfo],
     calc: Calculator,
     relaxCalc: Calculator,
     relax: bool,
-) -> Tuple[float, Atoms, Optional[np.ndarray]]:
+) -> tuple[float, Atoms, np.ndarray | None]:
     """Evaluate a dihedral guess, optionally also returning dE/dtheta.
 
     When ``state.use_gradients`` is set this projects the calculator's forces
@@ -569,14 +591,14 @@ def _evaluate_point(
 
 def _evaluate_initial_guesses(
     state: OptimizationState,
-    dihedrals: List[DihedralInfo],
+    dihedrals: list[DihedralInfo],
     calc: Calculator,
     relaxCalc: Calculator,
     relax: bool,
     init_steps: int,
     seed: int,
-    initial_conformers: Optional[List[Atoms]],
-    initial_dihedrals: Optional[np.ndarray] = None,
+    initial_conformers: list[Atoms] | None,
+    initial_dihedrals: np.ndarray | None = None,
 ) -> None:
     """Evaluate initial guesses and update state in-place.
 
@@ -660,11 +682,11 @@ def _evaluate_initial_guesses(
 def _run_optimization_loop(
     state: OptimizationState,
     n_steps: int,
-    dihedrals: List[DihedralInfo],
+    dihedrals: list[DihedralInfo],
     calc: Calculator,
     relaxCalc: Calculator,
     relax: bool,
-    out_dir: Optional[Path],
+    out_dir: Path | None,
 ) -> None:
     """Run the Bayesian optimization loop, updating state in-place.
 
@@ -760,7 +782,7 @@ def _run_optimization_loop(
 
 def _perform_final_relaxation(
     state: OptimizationState,
-    dihedrals: List[DihedralInfo],
+    dihedrals: list[DihedralInfo],
     calc: Calculator,
     relaxCalc: Calculator,
 ) -> Atoms:
@@ -866,7 +888,7 @@ def _select_ensemble_candidates(
     p_threshold: float,
     sigma_floor_eV: float,
     failure_energy_eV: float,
-) -> List[Tuple[np.ndarray, Atoms]]:
+) -> list[tuple[np.ndarray, Atoms]]:
     """Select observed conformers to tightly optimize, ordered by predicted energy.
 
     A conformer ``i`` is included iff its GP posterior gives
@@ -941,14 +963,14 @@ def _rmsd(a: Atoms, b: Atoms) -> float:
 
 
 def _dedup(
-    pairs: List[Tuple[Atoms, float]], rmsd_thr: float, e_tol_eV: float
-) -> List[Tuple[Atoms, float]]:
+    pairs: list[tuple[Atoms, float]], rmsd_thr: float, e_tol_eV: float
+) -> list[tuple[Atoms, float]]:
     """Deduplicate (atoms, energy_eV) pairs, assumed sorted by energy ascending.
 
     A structure is a duplicate iff it is BOTH energy-close AND geometry-close to
     an already-kept structure.
     """
-    unique: List[Tuple[Atoms, float]] = []
+    unique: list[tuple[Atoms, float]] = []
     for atoms, energy in pairs:
         if any(
             abs(energy - ue) < e_tol_eV and _rmsd(ua, atoms) < rmsd_thr
@@ -970,10 +992,10 @@ def _boltzmann_weights(energies_eV: np.ndarray, temperature: float) -> np.ndarra
 
 def _perform_ensemble_relaxation(
     state: OptimizationState,
-    dihedrals: List[DihedralInfo],
+    dihedrals: list[DihedralInfo],
     calc: Calculator,
     relaxCalc: Calculator,
-) -> List[Tuple[Atoms, float, float]]:
+) -> list[tuple[Atoms, float, float]]:
     """Select -> tight (unconstrained) optimize -> dedup -> Boltzmann weight.
 
     Returns ``[(atoms, relative_energy_eV, weight)]`` sorted by energy ascending,
@@ -992,7 +1014,7 @@ def _perform_ensemble_relaxation(
     )
 
     # Tight, UNCONSTRAINED optimization of each candidate (no step limit).
-    optimized: List[Tuple[Atoms, float]] = []
+    optimized: list[tuple[Atoms, float]] = []
     for k, (coords, atoms) in enumerate(candidates):
         a = atoms.copy()
         a.set_constraint()  # remove any dihedral constraints
@@ -1029,18 +1051,18 @@ def _perform_ensemble_relaxation(
 
 def run_optimization(
     atoms: Atoms,
-    dihedrals: List[DihedralInfo],
+    dihedrals: list[DihedralInfo],
     n_steps: int,
     calc: Calculator,
     relaxCalc: Calculator,
     init_steps: int,
-    out_dir: Optional[Path],
+    out_dir: Path | None,
     relax: bool = True,
     seed: int = 0,
-    initial_conformers: Optional[List[Atoms]] = None,
-    initial_dihedrals: Optional[np.ndarray] = None,
+    initial_conformers: list[Atoms] | None = None,
+    initial_dihedrals: np.ndarray | None = None,
     # New PiBO parameters
-    prior_module: Optional[DihedralPriorModule] = None,
+    prior_module: DihedralPriorModule | None = None,
     initial_prior_exponent: float = 2.0,
     prior_exponent_decay: float = 0.9,
     return_ensemble: bool = False,
@@ -1048,7 +1070,7 @@ def run_optimization(
     gradient_steps: int = 0,
     grad_refit_dense_until: int = 20,
     grad_refit_every: int = 0,
-) -> Union[Atoms, Tuple[Atoms, List[Tuple[Atoms, float, float]]]]:
+) -> Atoms | tuple[Atoms, list[tuple[Atoms, float, float]]]:
     """Optimize the structure of a molecule by iteratively changing the dihedral angles.
 
     Args:

--- a/bouquet/solver.py
+++ b/bouquet/solver.py
@@ -66,6 +66,14 @@ from bouquet.setup import DihedralInfo
 
 logger = logging.getLogger(__name__)
 
+# Marginal-likelihood Adam iterations for a cold gradient-GP hyperparameter fit
+# (see _fit_gradient_gp). Condition-only updates run 0 steps. A benchmark found
+# conformer quality is insensitive to fit convergence (50/100/200 steps gave
+# statistically indistinguishable minima despite very different final NLLs), so 100
+# trims the dense-phase cold fits at no quality cost; 50 showed a faint degradation
+# and is under-converged for larger molecules.
+_GRAD_GP_FIT_STEPS = 100
+
 
 def _get_device() -> torch.device:
     """Get the appropriate torch device (CUDA if available, else CPU)."""
@@ -95,6 +103,24 @@ class OptimizationState:
     # When True, evaluations also record dE/dtheta and the acquisition GP uses
     # the gradient-enhanced surrogate (see GradientEnhancedPeriodicGP).
     use_gradients: bool = False
+    # Number of leading BO steps that use the gradient-enhanced GP; once the loop
+    # passes this many steps it switches to the value-only GP (gradients are still
+    # recorded, just not fed to the surrogate). The gradient GP's per-step cost
+    # grows as O((n*(1+d))^3), so on large/floppy molecules it becomes intractable
+    # late in the run; spending the gradient signal early -- where it helps most --
+    # and then dropping to the cheap n*n GP keeps the search tractable. <=0 means
+    # never switch (gradient GP for the whole run).
+    gradient_steps: int = 0
+    # Gradient-GP hyperparameter refit schedule (see _run_optimization_loop). Cold
+    # full fits for the first `grad_refit_dense_until` BO steps, then the
+    # hyperparameters are frozen and later steps only re-condition; `grad_refit_every`
+    # > 0 optionally cold-refreshes them every that many post-dense steps. Default
+    # (20, 0) = the "gradfreeze" schedule; set grad_refit_dense_until=0 for a full fit
+    # every step. `grad_gp_hypers` holds the last cold-fitted hyperparameters (frozen
+    # on condition-only steps).
+    grad_refit_dense_until: int = 20
+    grad_refit_every: int = 0
+    grad_gp_hypers: Optional[dict] = None
 
     # PiBO fields
     prior_module: Optional[DihedralPriorModule] = None
@@ -159,8 +185,21 @@ def _fit_gradient_gp(
     energy_cap: torch.Tensor,
     observed_gradients: torch.Tensor,
     y_std: torch.Tensor,
+    frozen_hypers: Optional[dict] = None,
 ) -> GradientEnhancedPeriodicGP:
     """Build and fit the gradient-enhanced periodic GP on standardized data.
+
+    Two modes (see ``_run_optimization_loop``):
+    - ``frozen_hypers=None``: a cold fit -- optimize fresh hyperparameters with
+      ``_GRAD_GP_FIT_STEPS`` marginal-likelihood Adam iterations. The caller reads
+      ``gp.state_dict()`` afterwards to carry the hyperparameters forward.
+    - ``frozen_hypers`` set: a condition-only update -- load those hyperparameters
+      and fold in the new data for one Cholesky, running NO Adam steps.
+
+    We deliberately never optimize *from* loaded hyperparameters: warm-starting the
+    fit drifts them and degrades the search, so loaded hypers are only ever used for
+    conditioning. Collapsing the two knobs into one parameter makes that the only
+    expressible behavior.
 
     The acquisition GP fits standardized values ``y' = (-clamp(E) - mean)/std``
     over inputs ``x' = degrees / 360``. The stored gradients are ``dE/dtheta`` in
@@ -185,7 +224,12 @@ def _fit_gradient_gp(
     gp = GradientEnhancedPeriodicGP(
         train_x, train_y, grad_scaled, grad_mask=mask, period=1.0
     )
-    gp.fit(steps=200, lr=0.05)
+    if frozen_hypers is None:
+        gp.fit(steps=_GRAD_GP_FIT_STEPS, lr=0.05)  # cold fit: optimize fresh hypers
+    else:
+        # Condition-only: load the frozen hypers and re-condition (steps=0, no Adam).
+        gp.load_state_dict(frozen_hypers, strict=False)
+        gp.fit(steps=0, lr=0.05)
     return gp
 
 
@@ -196,6 +240,8 @@ def _select_next_points_botorch(
     prior_exponent: float = 0.0,
     observed_gradients: Optional[torch.Tensor] = None,
     use_gradients: bool = False,
+    gp_frozen_hypers: Optional[dict] = None,
+    gp_hyper_out: Optional[dict] = None,
 ) -> np.ndarray:
     """
     Selects the next dihedral coordinate to evaluate by fitting a Gaussian process to the observed data and optimizing a BOTorch acquisition function.
@@ -209,6 +255,12 @@ def _select_next_points_botorch(
             n_dims), index-aligned with ``train_X``; NaN rows are dropped.
         use_gradients: If True (and gradients are provided), fit the
             gradient-enhanced surrogate instead of the value-only GP.
+        gp_frozen_hypers: Optional state-dict of gradient-GP hyperparameters. None
+            does a cold fit (optimize fresh hyperparameters); a value loads those
+            hyperparameters and conditions only (no Adam). Ignored unless gradients
+            are used. (The value-only GP path always uses the standard fit.)
+        gp_hyper_out: If provided and gradients are used, this dict is populated
+            with ``{"hypers": <fitted state-dict>}`` for the caller to carry forward.
 
     Returns:
         np.ndarray: A 1-D array of length n_dims containing the proposed dihedral coordinates in degrees.
@@ -231,8 +283,15 @@ def _select_next_points_botorch(
 
     if use_gradients and observed_gradients is not None:
         gp = _fit_gradient_gp(
-            train_x, train_y, raw_y, energy_cap, observed_gradients, y_std
+            train_x, train_y, raw_y, energy_cap, observed_gradients, y_std,
+            frozen_hypers=gp_frozen_hypers,
         )
+        # Snapshot the fitted hyperparameters only when the caller asks (cold-fit
+        # steps), so frozen condition-only steps don't clone them needlessly.
+        if gp_hyper_out is not None:
+            gp_hyper_out["hypers"] = {
+                k: v.detach().clone() for k, v in gp.state_dict().items()
+            }
     else:
         # Make the GP
         # TODO: make the GP only once and reuse via updates
@@ -618,14 +677,61 @@ def _run_optimization_loop(
         relax: Whether to relax non-dihedral degrees of freedom
         out_dir: Output path for saving best structure
     """
+    # Optional grad->value handoff: use the gradient-enhanced GP only for the first
+    # `gradient_steps` BO steps, then the cheap value-only GP (see OptimizationState).
+    switch_at = state.gradient_steps if state.gradient_steps > 0 else None
+
+    # Gradient-GP hyperparameter refit schedule. A full fit runs ~200 Choleskys and
+    # its cost grows steeply with the observation count, so fitting every step
+    # dominates the run late on. Instead: full (cold) fits for the first
+    # `dense_until` BO steps -- hyperparameters move most early and the matrices are
+    # still small -- then FREEZE them and only re-condition, which folds each new
+    # point in under the frozen hyperparameters for one Cholesky instead of ~200
+    # (a cold fit vs. a condition-only update, selected per step below via
+    # `gp_frozen_hypers`). `refit_every > 0` optionally refreshes the frozen
+    # hyperparameters with a *cold* refit every that many post-dense steps (cold,
+    # not warm-started: warm-starting the fit drifts the hyperparameters and
+    # degrades the search). The shipped default freezes after `dense_until` steps;
+    # the opt-out `dense_until=0` (with `refit_every<=1`) refits every step -- the
+    # slow full-gradient reference. See _fit_gradient_gp.
+    dense_until = max(0, state.grad_refit_dense_until)
+    refit_every = state.grad_refit_every
+    schedule_active = dense_until > 0 or refit_every > 1
+
     for step in range(n_steps):
+        step_uses_gradients = state.use_gradients and (
+            switch_at is None or step < switch_at
+        )
+        if switch_at is not None and state.use_gradients and step == switch_at:
+            logger.info(
+                f"Switching to value-only GP after {switch_at} gradient-enhanced "
+                f"step(s) (gradient GP cost grows with observation count)."
+            )
+
+        # Per-step gradient-GP cost: a cold full fit (no schedule, dense phase,
+        # periodic refresh, or the mandatory first fit) vs. a condition-only update
+        # that reuses the frozen hyperparameters and runs no Adam. Only a cold fit
+        # produces new hyperparameters, so only then do we snapshot them (via a
+        # non-None gp_hyper_out) to freeze on later steps.
+        cold_fit = True
+        if step_uses_gradients and schedule_active and state.grad_gp_hypers is not None:
+            on_refit = refit_every > 0 and (step - dense_until) % refit_every == 0
+            cold_fit = step < dense_until or on_refit
+        # Snapshot fitted hypers only on a cold fit under an active schedule -- i.e.
+        # only when a later step will actually freeze on them.
+        hyper_out = {} if step_uses_gradients and cold_fit and schedule_active else None
+
         next_coords = _select_next_points_botorch(
             state.observed_coords, state.observed_energies,
             prior_module=state.prior_module,
             prior_exponent=state.prior_exponent,
             observed_gradients=state.observed_gradients,
-            use_gradients=state.use_gradients,
+            use_gradients=step_uses_gradients,
+            gp_frozen_hypers=None if cold_fit else state.grad_gp_hypers,
+            gp_hyper_out=hyper_out,
         )
+        if hyper_out:  # a cold fit; carry its hyperparameters forward to freeze
+            state.grad_gp_hypers = hyper_out["hypers"]
         # logger.info(f'Selected next point: {next_coords}')
 
         energy, cur_atoms, gradient = _evaluate_point(
@@ -939,6 +1045,9 @@ def run_optimization(
     prior_exponent_decay: float = 0.9,
     return_ensemble: bool = False,
     use_gradients: bool = False,
+    gradient_steps: int = 0,
+    grad_refit_dense_until: int = 20,
+    grad_refit_every: int = 0,
 ) -> Union[Atoms, Tuple[Atoms, List[Tuple[Atoms, float, float]]]]:
     """Optimize the structure of a molecule by iteratively changing the dihedral angles.
 
@@ -966,6 +1075,26 @@ def run_optimization(
             energy objective when ``calc`` and ``relaxCalc`` are the same surface
             (the envelope theorem needs the geometry to be a constrained minimum
             of the energy calculator); pass matching calculators in that case.
+        gradient_steps: If > 0 (and ``use_gradients``), use the gradient-enhanced
+            GP only for the first ``gradient_steps`` BO steps, then switch to the
+            value-only GP for the remainder. The gradient GP's per-step cost grows
+            steeply with the observation count, so this caps it on large molecules
+            while keeping the early-search benefit. <=0 keeps gradients for the
+            whole run; a budget smaller than ``gradient_steps`` never switches.
+        grad_refit_dense_until: Number of leading BO steps that do a full
+            gradient-GP hyperparameter fit. Refitting is the dominant cost (~200
+            Choleskys, growing with observation count), so beyond this the
+            hyperparameters are frozen and later steps only re-condition (one
+            Cholesky). Hyperparameters move most early, when the matrices are still
+            small, so the cold fits there are both useful and cheap. Default 20
+            (validated quality-neutral vs full refitting for 5-11 dihedrals); 0
+            refits every step (the slow full-gradient reference).
+        grad_refit_every: After the dense phase, optionally do a *cold* refit of the
+            frozen hyperparameters every this many BO steps (<=0 or 1 with no dense
+            phase keeps the original full-fit-every-step behavior; >0 with a dense
+            phase refreshes periodically, 0 freezes for the rest of the run). Cold,
+            not warm-started: warm-starting the fit drifts the hyperparameters and
+            degrades the search.
 
     Returns:
         If ``return_ensemble`` is False, the optimized lowest-energy geometry as
@@ -987,6 +1116,9 @@ def run_optimization(
     state = _setup_initial_state(
         atoms, dihedrals, calc, relaxCalc, relax, out_dir, use_gradients=use_gradients
     )
+    state.gradient_steps = gradient_steps
+    state.grad_refit_dense_until = grad_refit_dense_until
+    state.grad_refit_every = grad_refit_every
 
     # Add prior settings to state
     state.prior_module = prior_module

--- a/bouquet/solver.py
+++ b/bouquet/solver.py
@@ -250,7 +250,7 @@ def _fit_gradient_gp(
         gp.fit(steps=_GRAD_GP_FIT_STEPS, lr=0.05)  # cold fit: optimize fresh hypers
     else:
         # Condition-only: load the frozen hypers and re-condition (steps=0, no Adam).
-        gp.load_state_dict(frozen_hypers, strict=False)
+        gp.load_state_dict(frozen_hypers, strict=True)
         gp.fit(steps=0, lr=0.05)
     return gp
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -3,11 +3,30 @@ authors = [
 {name = "Geoff Hutchison", email = "geoff.hutchison@gmail.com"},
 {name = "Logan Ward", email = "lward@anl.gov" },
 ]
-name = "bouquet"
+name = "bouquet-mol"
 requires-python = ">= 3.11"
 version = "0.5.0"
 description = 'Molecular conformer optimization via Bayesian optimization'
 readme = "README.md"
+license = "MIT"
+license-files = ["LICENSE"]
+keywords = [
+    "chemistry",
+    "conformers",
+    "bayesian-optimization",
+    "molecular-modeling",
+    "computational-chemistry",
+    "rdkit",
+]
+classifiers = [
+    "Development Status :: 4 - Beta",
+    "Intended Audience :: Science/Research",
+    "Programming Language :: Python :: 3",
+    "Programming Language :: Python :: 3.11",
+    "Programming Language :: Python :: 3.12",
+    "Topic :: Scientific/Engineering :: Chemistry",
+    "Operating System :: OS Independent",
+]
 dependencies = [
     "rdkit",
     "networkx",
@@ -27,7 +46,9 @@ test = ["pytest>=9.0", "pytest-cov>=7.0"]
 irmsd = ["irmsd>=0.1.1"]
 
 [project.urls]
+Homepage = "https://github.com/ghutchis/bouquet"
 Repository = "https://github.com/ghutchis/bouquet"
+Issues = "https://github.com/ghutchis/bouquet/issues"
 
 [project.scripts]
 bouquet = "bouquet.cli:main"

--- a/scripts/grad_kernel_gate.py
+++ b/scripts/grad_kernel_gate.py
@@ -1,0 +1,349 @@
+"""Phase-1 gate: decide the gradient-enhanced GP kernel route (a) vs (b).
+
+This is a *synthetic* validation harness, not a unit test and not part of the
+shipped package. It answers one question before we commit to the harder
+value-posterior BoTorch wrapper:
+
+    Which periodic gradient-enhanced GP kernel should bouquet use?
+
+    (a) sin/cos input embedding + RBF      -> k(d) = exp(-(1 - cos d) / l^2)
+    (b) native periodic kernel             -> k(d) = exp(-2 sin^2(pi d / P) / l^2)
+
+Both are smooth periodic kernels, so we can build *both* gradient-enhanced GPs
+in identical inference code and let the kernel be the only variable. We obtain
+every first/second cross-derivative the gradient-enhanced covariance needs from
+``torch.func`` autograd -- for a validation gate we only need the blocks to be
+*correct*, not in closed form (the closed forms are only needed later, for the
+production gpytorch kernel, and only for route (b)).
+
+What we measure, mirroring the Phase-0 finite-difference gate:
+
+  1. Posterior-mean RMSE vs. training size n (data efficiency). A gradient-
+     enhanced GP must beat the value-only GP at equal n or the effort is moot.
+  2. Posterior-gradient error vs. the analytic gradient (the Phase-0 tolerance,
+     lifted to the GP posterior).
+  3. Conditioning of the gradient-augmented covariance (the practical failure
+     mode that separates the two routes more than accuracy does).
+
+Run:  KMP_DUPLICATE_LIB_OK=TRUE pixi run python scripts/grad_kernel_gate.py
+"""
+
+from __future__ import annotations
+
+import math
+from dataclasses import dataclass
+from typing import Callable, Dict, List, Tuple
+
+import torch
+from torch.func import jacrev, vmap
+
+torch.set_default_dtype(torch.float64)
+TWO_PI = 2.0 * math.pi
+
+
+# ---------------------------------------------------------------------------
+# Synthetic periodic test functions (torsion-like Fourier potentials).
+# Each returns a scalar; gradients come from autograd so "truth" is exact.
+# ---------------------------------------------------------------------------
+def f_1d(x: torch.Tensor) -> torch.Tensor:
+    t = x[0]
+    return torch.cos(t) + 0.6 * torch.cos(2 * t - 0.7) + 0.3 * torch.cos(3 * t + 1.2)
+
+
+def f_2d(x: torch.Tensor) -> torch.Tensor:
+    t1, t2 = x[0], x[1]
+    return torch.cos(t1) + torch.cos(t2) + 0.5 * torch.cos(t1 - t2)
+
+
+def f_3d(x: torch.Tensor) -> torch.Tensor:
+    t1, t2, t3 = x[0], x[1], x[2]
+    return (
+        torch.cos(t1)
+        + 0.7 * torch.cos(2 * t2)
+        + torch.cos(t3)
+        + 0.4 * torch.cos(t1 - t3)
+    )
+
+
+@dataclass
+class TestProblem:
+    name: str
+    d: int
+    fn: Callable[[torch.Tensor], torch.Tensor]
+
+
+PROBLEMS = [
+    TestProblem("1D (3-term Fourier)", 1, f_1d),
+    TestProblem("2D (coupled)", 2, f_2d),
+    TestProblem("3D (coupled)", 3, f_3d),
+]
+
+
+def eval_with_grad(fn: Callable, X: torch.Tensor) -> tuple[torch.Tensor, torch.Tensor]:
+    """Vectorized (value, gradient) of ``fn`` over a batch of points X (n, d)."""
+    vals = vmap(fn)(X)
+    grads = vmap(jacrev(fn))(X)
+    return vals, grads
+
+
+# ---------------------------------------------------------------------------
+# Per-dim periodic kernels. d = x - x' (radians). Product over dims gives the
+# full kernel; outputscale and lengthscale are applied in the GP wrapper.
+# ---------------------------------------------------------------------------
+def _embedding_perdim(d: torch.Tensor, ell: torch.Tensor) -> torch.Tensor:
+    # (a) RBF on (cos, sin): ||e(t)-e(t')||^2 = 2 - 2 cos d  ->  exp(-(1-cos d)/l^2)
+    return torch.exp(-(1.0 - torch.cos(d)) / (ell**2))
+
+
+def _periodic_perdim(d: torch.Tensor, ell: torch.Tensor) -> torch.Tensor:
+    # (b) gpytorch-style periodic kernel, period = 2*pi
+    s = torch.sin(math.pi * d / TWO_PI)
+    return torch.exp(-2.0 * s**2 / (ell**2))
+
+
+def make_kernel(perdim: Callable) -> Callable:
+    """Build k(x1, x2, outputscale, lengthscale) -> scalar from a per-dim factor."""
+
+    def k(x1: torch.Tensor, x2: torch.Tensor, os: torch.Tensor, ell: torch.Tensor):
+        factors = perdim(x1 - x2, ell)
+        return os * torch.prod(factors)
+
+    return k
+
+
+# ---------------------------------------------------------------------------
+# Gradient-enhanced exact GP. Observation block per point is [f, df/dx_1, ...].
+# Every kernel block comes from autograd of the scalar kernel k(x1, x2), but
+# evaluated *batched* over all point pairs at once via vmap (the Python-loop
+# version was ~100x slower). Posterior gradients are assembled from the same
+# kernel-derivative primitives rather than nesting autograd at predict time.
+# ---------------------------------------------------------------------------
+class GradGP:
+    def __init__(self, kernel: Callable, with_grad: bool):
+        self.kernel = kernel
+        self.with_grad = with_grad
+
+    def _primitives(self, A, B, os, ell):
+        """Batched kernel and its derivatives over all pairs (A_i, B_j).
+
+        Returns (kv, dB, dA, h) with shapes (p,q), (p,q,d), (p,q,d), (p,q,d,d).
+        dB = d k / d B  (grad wrt 2nd arg),  dA = d k / d A,  h = d^2k / dA dB.
+        """
+        k = lambda a, b: self.kernel(a, b, os, ell)
+        p, q, d = A.shape[0], B.shape[0], A.shape[1]
+        Af = A[:, None, :].expand(p, q, d).reshape(-1, d)
+        Bf = B[None, :, :].expand(p, q, d).reshape(-1, d)
+        kv = vmap(k)(Af, Bf).reshape(p, q)
+        if not self.with_grad:
+            return kv, None, None, None
+        dB = vmap(jacrev(k, argnums=1))(Af, Bf).reshape(p, q, d)
+        dA = vmap(jacrev(k, argnums=0))(Af, Bf).reshape(p, q, d)
+        h = vmap(jacrev(jacrev(k, argnums=0), argnums=1))(Af, Bf).reshape(p, q, d, d)
+        return kv, dB, dA, h
+
+    def _assemble(self, kv, dB, dA, h):
+        """Stack per-pair (1+d, 1+d) blocks into a full (p(1+d), q(1+d)) matrix."""
+        p, q = kv.shape
+        if not self.with_grad:
+            return kv
+        d = dB.shape[-1]
+        M = torch.empty(p, 1 + d, q, 1 + d)
+        M[:, 0, :, 0] = kv          # cov(f_i, f_j)
+        M[:, 0, :, 1:] = dB         # cov(f_i, g_j)
+        M[:, 1:, :, 0] = dA.permute(0, 2, 1)   # cov(g_i, f_j)
+        M[:, 1:, :, 1:] = h.permute(0, 2, 1, 3)  # cov(g_i, g_j)
+        return M.reshape(p * (1 + d), q * (1 + d))
+
+    def _full_K(self, X, os, ell):
+        return self._assemble(*self._primitives(X, X, os, ell))
+
+    @staticmethod
+    def _stack_targets(vals, grads, with_grad):
+        if not with_grad:
+            return vals.reshape(-1, 1)
+        n, d = grads.shape
+        return torch.cat([vals.reshape(n, 1), grads], dim=1).reshape(-1, 1)
+
+    # ---- fit / predict -------------------------------------------------------
+    def fit(self, X, vals, grads, steps=150, lr=0.05):
+        y = self._stack_targets(vals, grads, self.with_grad)
+        self._y, self._X = y, X
+        log_os = torch.zeros(1, requires_grad=True)
+        log_ell = torch.zeros(1, requires_grad=True)
+        log_noise = torch.full((1,), math.log(1e-3), requires_grad=True)
+        opt = torch.optim.Adam([log_os, log_ell, log_noise], lr=lr)
+        N = y.shape[0]
+        for _ in range(steps):
+            opt.zero_grad()
+            os = torch.exp(log_os)
+            ell = torch.exp(log_ell).clamp(min=1e-2)
+            noise = torch.exp(log_noise).clamp(min=1e-6)
+            K = self._full_K(X, os, ell) + noise * torch.eye(N)
+            L = torch.linalg.cholesky(K)
+            alpha = torch.cholesky_solve(y, L)
+            nll = 0.5 * (y * alpha).sum() + torch.log(torch.diagonal(L)).sum()
+            nll.backward()
+            opt.step()
+        with torch.no_grad():
+            self.os = torch.exp(log_os).detach()
+            self.ell = torch.exp(log_ell).clamp(min=1e-2).detach()
+            self.noise = torch.exp(log_noise).clamp(min=1e-6).detach()
+            K = self._full_K(X, self.os, self.ell) + self.noise * torch.eye(N)
+            self._L = torch.linalg.cholesky(K)
+            self._alpha = torch.cholesky_solve(y, self._L)
+            self._condK = torch.linalg.cond(K).item()
+        return self
+
+    def posterior_mean_and_grad(self, Xstar):
+        """Posterior mean and its gradient at test points, both in closed form.
+
+        mean(x*)      = cov(f(x*), train) @ alpha
+        grad mean(x*) = cov(grad f(x*), train) @ alpha
+        Both cross-covariances reuse the kernel-derivative primitives between
+        the test points (A = Xstar) and the training points (B = X).
+        """
+        with torch.no_grad():
+            kv, dB, dA, h = self._primitives(Xstar, self._X, self.os, self.ell)
+            m, n = kv.shape
+            d = Xstar.shape[1]
+            if self.with_grad:
+                # cross(f*, [f_j, g_j]) : (m, n*(1+d))
+                cf = torch.empty(m, n, 1 + d)
+                cf[:, :, 0] = kv
+                cf[:, :, 1:] = dB
+                mean = (cf.reshape(m, n * (1 + d)) @ self._alpha).reshape(m)
+                # cross(g*_a, [f_j, g_j]) : (m, d, n*(1+d))
+                cg = torch.empty(m, d, n, 1 + d)
+                cg[:, :, :, 0] = dA.permute(0, 2, 1)
+                cg[:, :, :, 1:] = h.permute(0, 2, 1, 3)
+                gmean = (cg.reshape(m, d, n * (1 + d)) @ self._alpha).reshape(m, d)
+            else:
+                mean = (kv @ self._alpha).reshape(m)
+                # value-only GP: still differentiate the cross-cov wrt x* for
+                # the posterior-mean gradient (dA = d k(x*, X_j) / d x*).
+                k = lambda a, b: self.kernel(a, b, self.os, self.ell)
+                Af = Xstar[:, None, :].expand(m, n, d).reshape(-1, d)
+                Bf = self._X[None, :, :].expand(m, n, d).reshape(-1, d)
+                dA = vmap(jacrev(k, argnums=0))(Af, Bf).reshape(m, n, d)
+                gmean = (dA.permute(0, 2, 1) @ self._alpha).reshape(m, d)
+        return mean, gmean
+
+
+# ---------------------------------------------------------------------------
+# Sampling / metrics
+# ---------------------------------------------------------------------------
+def sobol_like(n, d, seed):
+    g = torch.Generator().manual_seed(seed)
+    return torch.rand(n, d, generator=g) * TWO_PI
+
+
+def dense_grid(d, per_dim=24):
+    axis = torch.linspace(0, TWO_PI, per_dim + 1)[:-1]
+    mesh = torch.meshgrid(*([axis] * d), indexing="ij")
+    return torch.stack([m.reshape(-1) for m in mesh], dim=1)
+
+
+def rmse(a, b):
+    return torch.sqrt(torch.mean((a - b) ** 2)).item()
+
+
+KERNELS = {
+    "value-only (periodic)": (make_kernel(_periodic_perdim), False),
+    "(a) embedding+RBF": (make_kernel(_embedding_perdim), True),
+    "(b) native periodic": (make_kernel(_periodic_perdim), True),
+}
+
+
+def run_problem(problem: TestProblem, n_values: list[int], seeds: list[int]):
+    Xtest = dense_grid(problem.d, per_dim=16 if problem.d <= 2 else 8)
+    ytest, gtest = eval_with_grad(problem.fn, Xtest)
+    results: dict[str, dict[int, dict[str, list[float]]]] = {
+        name: {n: {"mean": [], "grad": [], "cond": []} for n in n_values}
+        for name in KERNELS
+    }
+    for n in n_values:
+        for seed in seeds:
+            Xtr = sobol_like(n, problem.d, seed)
+            ytr, gtr = eval_with_grad(problem.fn, Xtr)
+            for name, (kern, with_grad) in KERNELS.items():
+                gp = GradGP(kern, with_grad).fit(Xtr, ytr, gtr)
+                mean, gmean = gp.posterior_mean_and_grad(Xtest)
+                results[name][n]["mean"].append(rmse(mean, ytest))
+                results[name][n]["grad"].append(rmse(gmean, gtest))
+                results[name][n]["cond"].append(gp._condK)
+    return results
+
+
+def fmt(vals: list[float]) -> str:
+    t = torch.tensor(vals)
+    return f"{t.mean():.4f}+-{t.std():.4f}"
+
+
+def kernel_identity_check():
+    """Show analytically/numerically that (a) and (b) are the SAME kernel.
+
+    embedding-RBF:  exp(-(1 - cos d) / l^2)
+    native periodic: exp(-2 sin^2(d/2) / l^2)   and   2 sin^2(d/2) = 1 - cos d
+    => identical at equal lengthscale. So accuracy/conditioning cannot separate
+    the two routes; only the *implementation* differs.
+    """
+    d = torch.linspace(-math.pi, math.pi, 401)
+    ell = torch.tensor(0.8)
+    a = torch.exp(-(1.0 - torch.cos(d)) / ell**2)
+    b = torch.exp(-2.0 * torch.sin(math.pi * d / TWO_PI) ** 2 / ell**2)
+    print("=" * 78)
+    print("Kernel identity  (a) embedding-RBF  vs  (b) native periodic")
+    print("=" * 78)
+    print(f"  max |k_a(d) - k_b(d)| over [-pi, pi] at equal lengthscale: "
+          f"{(a - b).abs().max().item():.2e}")
+    print("  => same function; the gate's matching rows below are exact, not a bug.\n")
+
+
+def cost_model():
+    """The thing that actually differs: gradient-augmented matrix size and the
+    nature of the gradient observation, per torsion dimension d, n points."""
+    print("=" * 78)
+    print("What differs between the routes (per d torsions, n points)")
+    print("=" * 78)
+    print("  (b) native PeriodicKernelGrad:")
+    print("      - covariance dim N = n*(1 + d)        [1 gradient slot / torsion]")
+    print("      - gradient obs = dE/dtheta, exactly what gradients.py returns")
+    print("      - drops straight into a periodic value-posterior wrapper")
+    print("  (a) stock gpytorch RBFKernelGrad on (cos,sin) embedding:")
+    print("      - input dim doubles: d torsions -> 2d embedding coords")
+    print("      - covariance dim N = n*(1 + 2d)       [2 gradient slots / torsion]")
+    print("      - RBFKernelGrad wants d/d(cos), d/d(sin) SEPARATELY, but only the")
+    print("        tangential combo (-sin, cos).dE/dtheta is physical; the radial")
+    print("        partial is off-manifold and must be faked (tangential lift).")
+    print("      - same kernel as (b), obtained less efficiently + an approximation\n")
+
+
+def main():
+    kernel_identity_check()
+    cost_model()
+    n_values = [6, 10, 16]
+    seeds = list(range(6))
+    for problem in PROBLEMS:
+        print("\n" + "=" * 78)
+        print(f"{problem.name}   (d={problem.d}, {len(seeds)} seeds)")
+        print("=" * 78)
+        res = run_problem(problem, n_values, seeds)
+        for metric, label in [("mean", "posterior-mean RMSE"), ("grad", "gradient RMSE")]:
+            print(f"\n  {label}:")
+            header = "    {:<24}".format("kernel") + "".join(
+                f"n={n:<14}" for n in n_values
+            )
+            print(header)
+            for name in KERNELS:
+                row = "    {:<24}".format(name)
+                for n in n_values:
+                    row += "{:<16}".format(fmt(res[name][n][metric]))
+                print(row)
+        print("\n  covariance condition number (median over seeds, largest n):")
+        for name in KERNELS:
+            c = torch.tensor(res[name][n_values[-1]]["cond"]).median().item()
+            print(f"    {name:<24} {c:.2e}")
+
+
+if __name__ == "__main__":
+    main()

--- a/scripts/gradient_benchmark.py
+++ b/scripts/gradient_benchmark.py
@@ -1,0 +1,143 @@
+"""Phase-3 payoff: calls-to-minimum, gradient-enhanced GP vs value-only GP.
+
+The hypothesis behind gradient-enhanced BO is data efficiency: each energy
+evaluation also contributes dE/dtheta, so the surrogate should locate the
+minimum in fewer calls. This benchmark runs both surrogates on a set of flexible
+molecules (paired seeds, fixed budget) and reports:
+
+  * final best relative energy at the budget (lower = better), and
+  * calls-to-minimum: the first evaluation reaching within EPS of a per-molecule
+    reference minimum (censored at the budget if never reached).
+
+The reference minimum per molecule is the best energy found across a generous
+random-sampling baseline plus both methods' own trajectories, so it does not
+favor either surrogate.
+
+Run: KMP_DUPLICATE_LIB_OK=TRUE PYTHONPATH=. pixi run python \
+        scripts/gradient_benchmark.py [--backend mmff|gfnff]
+"""
+
+from __future__ import annotations
+
+import argparse
+import contextlib
+import os
+
+import numpy as np
+import torch
+
+from bouquet import solver
+from bouquet.calc_rdkit import RDKitMMFFCalculator
+from bouquet.calculator import CalculatorFactory
+from bouquet.setup import detect_dihedrals, get_initial_structure
+
+MOLECULES = {
+    "butanediol": "OCCCCO",
+    "pentanediol": "OCCCCCO",
+    "diethyleneglycol": "OCCOCCO",
+    "aminopentanol": "NCCCCCO",
+}
+SEEDS = [0, 1, 2, 3]
+INIT_STEPS = 5
+N_STEPS = 30
+EPS = 0.043  # ~1 kcal/mol: "reached the minimum" tolerance (eV)
+
+
+@contextlib.contextmanager
+def _silence():
+    with open(os.devnull, "w") as dn:
+        old = os.dup(1)
+        os.dup2(dn.fileno(), 1)
+        try:
+            yield
+        finally:
+            os.dup2(old, 1)
+            os.close(old)
+
+
+def _make_calc(mol, backend):
+    if backend == "mmff":
+        return RDKitMMFFCalculator(mol)
+    return CalculatorFactory.create("gfnff", mol=mol)
+
+
+def run_bo(smiles, seed, use_gradients, backend):
+    """Return the best-so-far energy trace over all evaluations (eV, rel)."""
+    torch.manual_seed(seed)
+    atoms, mol = get_initial_structure(smiles)
+    dihedrals = detect_dihedrals(mol)
+    calc = _make_calc(mol, backend)
+    with _silence():
+        state = solver._setup_initial_state(atoms, dihedrals, calc, calc, True, None)
+        state.prior_module = None
+        state.use_gradients = use_gradients
+        solver._evaluate_initial_guesses(
+            state, dihedrals, calc, calc, True, INIT_STEPS, seed, None, None
+        )
+        solver._run_optimization_loop(
+            state, N_STEPS, dihedrals, calc, calc, True, None
+        )
+    e = state.observed_energies.detach().cpu().numpy()
+    return np.minimum.accumulate(e)
+
+
+def calls_to_min(trace, ref, eps, budget):
+    """First index (1-based, excluding the start point) within eps of ref."""
+    hit = np.where(trace <= ref + eps)[0]
+    if hit.size == 0:
+        return budget + 1  # censored
+    return int(hit[0])
+
+
+def main():
+    ap = argparse.ArgumentParser()
+    ap.add_argument("--backend", choices=["mmff", "gfnff"], default="mmff")
+    args = ap.parse_args()
+
+    print(f"backend={args.backend}  init={INIT_STEPS}  n_steps={N_STEPS}  "
+          f"seeds={SEEDS}  eps={EPS} eV")
+    print(f"{'molecule':<18}{'d':>3} {'best nograd':>12}{'best grad':>11}"
+          f"{'regret imp':>12}{'calls nograd':>13}{'calls grad':>11}")
+
+    budget = INIT_STEPS + N_STEPS
+    grand = {"reg_imp": [], "calls_ng": [], "calls_g": [], "win": 0, "loss": 0, "tie": 0,
+             "faster": 0, "slower": 0, "same": 0}
+    for name, smiles in MOLECULES.items():
+        _, mol = get_initial_structure(smiles)
+        d = len(detect_dihedrals(mol))
+        # collect traces
+        tr_ng = [run_bo(smiles, s, False, args.backend) for s in SEEDS]
+        tr_g = [run_bo(smiles, s, True, args.backend) for s in SEEDS]
+        ref = min(min(t[-1] for t in tr_ng), min(t[-1] for t in tr_g))
+        bn = np.mean([t[-1] for t in tr_ng])
+        bg = np.mean([t[-1] for t in tr_g])
+        cn = np.mean([calls_to_min(t, ref, EPS, budget) for t in tr_ng])
+        cg = np.mean([calls_to_min(t, ref, EPS, budget) for t in tr_g])
+        for tn, tg in zip(tr_ng, tr_g):
+            if tg[-1] < tn[-1] - 1e-4:
+                grand["win"] += 1
+            elif tg[-1] > tn[-1] + 1e-4:
+                grand["loss"] += 1
+            else:
+                grand["tie"] += 1
+            c_n, c_g = calls_to_min(tn, ref, EPS, budget), calls_to_min(tg, ref, EPS, budget)
+            if c_g < c_n:
+                grand["faster"] += 1
+            elif c_g > c_n:
+                grand["slower"] += 1
+            else:
+                grand["same"] += 1
+        grand["reg_imp"].append(bn - bg); grand["calls_ng"].append(cn); grand["calls_g"].append(cg)
+        print(f"{name:<18}{d:>3} {bn:>12.4f}{bg:>11.4f}{bn - bg:>12.4f}"
+              f"{cn:>13.1f}{cg:>11.1f}")
+    print("-" * 79)
+    print(f"{'mean':<21} {'':>12}{'':>11}{np.mean(grand['reg_imp']):>12.4f}"
+          f"{np.mean(grand['calls_ng']):>13.1f}{np.mean(grand['calls_g']):>11.1f}")
+    print(f"\nfinal-best   grad better: {grand['win']}  worse: {grand['loss']}  tie: {grand['tie']}")
+    print(f"calls-to-min grad faster: {grand['faster']}  slower: {grand['slower']}  same: {grand['same']}")
+    print("(regret imp > 0 and fewer calls favor the gradient-enhanced GP; "
+          "calls censored at budget+1 if the minimum was never reached.)")
+
+
+if __name__ == "__main__":
+    main()

--- a/scripts/gradient_benchmark.py
+++ b/scripts/gradient_benchmark.py
@@ -47,8 +47,8 @@ EPS = 0.043  # ~1 kcal/mol: "reached the minimum" tolerance (eV)
 def _silence():
     with open(os.devnull, "w") as dn:
         old = os.dup(1)
-        os.dup2(dn.fileno(), 1)
         try:
+            os.dup2(dn.fileno(), 1)
             yield
         finally:
             os.dup2(old, 1)

--- a/scripts/period_fix_benchmark.py
+++ b/scripts/period_fix_benchmark.py
@@ -1,0 +1,93 @@
+"""Quick before/after check for the periodic-kernel period fix.
+
+Background: the value-only BO surrogate normalizes dihedral inputs by /360 (full
+turn = 1.0), but historically set the periodic kernel period to 360, which makes
+the covariance near-degenerate on [0, 1] inputs (k(0deg, 180deg) ~= 1). The fix
+sets the period to 1.0 (config.GP_PERIOD_LENGTH_MEAN).
+
+This script runs the *value-only* optimizer on a few small molecules with the
+old (360) and new (1.0) period, fixed seeds, fixed evaluation budget, and
+compares the best relative energy found (lower is better). It reuses the solver's
+internal pipeline so we can read the full energy trace.
+
+Run: KMP_DUPLICATE_LIB_OK=TRUE pixi run python scripts/period_fix_benchmark.py
+"""
+
+from __future__ import annotations
+
+import numpy as np
+
+from bouquet import solver
+from bouquet.calc_rdkit import RDKitMMFFCalculator
+from bouquet.setup import detect_dihedrals, get_initial_structure
+
+# Flexible H-bonding chains whose *folded* (gauche) conformer is well below the
+# extended start geometry -- so finding the minimum genuinely exercises the
+# surrogate's point selection (rather than the start already being optimal).
+MOLECULES = {
+    "butanediol": "OCCCCO",
+    "pentanediol": "OCCCCCO",
+    "diethyleneglycol": "OCCOCCO",
+    "aminobutanol": "NCCCCO",
+}
+SEEDS = [0, 1, 2, 3]
+INIT_STEPS = 6
+N_STEPS = 30
+RELAX = True
+
+
+def run_once(smiles: str, seed: int, period_mean: float) -> np.ndarray:
+    """Run the value-only optimizer; return the best-so-far energy trace (eV)."""
+    solver.GP_PERIOD_LENGTH_MEAN = period_mean  # patched module global
+    atoms, mol = get_initial_structure(smiles)
+    dihedrals = detect_dihedrals(mol)
+    calc = RDKitMMFFCalculator(mol)
+
+    state = solver._setup_initial_state(atoms, dihedrals, calc, calc, RELAX, None)
+    state.prior_module = None
+    solver._evaluate_initial_guesses(
+        state, dihedrals, calc, calc, RELAX, INIT_STEPS, seed, None, None
+    )
+    solver._run_optimization_loop(state, N_STEPS, dihedrals, calc, calc, RELAX, None)
+    energies = state.observed_energies.detach().cpu().numpy()
+    return np.minimum.accumulate(energies)
+
+
+def main():
+    print(f"init_steps={INIT_STEPS}  n_steps={N_STEPS}  seeds={SEEDS}")
+    print(f"{'molecule':<17}{'d':>3}  {'best old(360)':>14}{'best new(1.0)':>14}"
+          f"{'improvement':>13}{'new wins':>10}")
+    grand_old, grand_new = [], []
+    wins = losses = ties = 0
+    for name, smiles in MOLECULES.items():
+        _, mol = get_initial_structure(smiles)
+        d = len(detect_dihedrals(mol))
+        best_old, best_new = [], []
+        nwin = 0
+        for seed in SEEDS:
+            old = run_once(smiles, seed, 360.0)[-1]
+            new = run_once(smiles, seed, 1.0)[-1]
+            best_old.append(old)
+            best_new.append(new)
+            if new < old - 1e-4:
+                nwin += 1
+                wins += 1
+            elif new > old + 1e-4:
+                losses += 1
+            else:
+                ties += 1
+        mo, mn = float(np.mean(best_old)), float(np.mean(best_new))
+        grand_old.append(mo)
+        grand_new.append(mn)
+        print(f"{name:<17}{d:>3}  {mo:>14.4f}{mn:>14.4f}{mo - mn:>13.4f}"
+              f"{f'{nwin}/{len(SEEDS)}':>10}")
+    print("-" * 71)
+    print(f"{'mean':<20}  {np.mean(grand_old):>14.4f}{np.mean(grand_new):>14.4f}"
+          f"{np.mean(grand_old) - np.mean(grand_new):>13.4f}")
+    print(f"\nper-(molecule,seed) record  new better: {wins}   worse: {losses}   tie: {ties}")
+    print("(energies relative to start geometry, eV; lower = better;"
+          " positive improvement = new period found a lower minimum)")
+
+
+if __name__ == "__main__":
+    main()

--- a/scripts/plot_bo_1d.py
+++ b/scripts/plot_bo_1d.py
@@ -151,6 +151,13 @@ def fit_arm(
     acqf = LogExpectedImprovement(gp, best_f=train_y.max(), maximize=True)
     with torch.no_grad():
         log_ei = acqf(gx.unsqueeze(1))  # (M,1,1) -> (M,)
+    # Exclude grid points already evaluated (selected angles are grid points and
+    # get appended verbatim) so EI can't re-propose a sampled angle and stall.
+    step = 360.0 / len(grid_deg)
+    gap = np.abs(grid_deg[:, None] - obs_deg[None, :])
+    gap = np.minimum(gap, 360.0 - gap)  # periodic distance
+    sampled = torch.from_numpy((gap < step / 2).any(axis=1))
+    log_ei = log_ei.masked_fill(sampled, float("-inf"))
     ei = log_ei.exp()
     next_deg = float(grid_deg[int(ei.argmax())])
 
@@ -342,6 +349,12 @@ def main():
     )
     ap.add_argument("--seed", type=int, default=0)
     args = ap.parse_args()
+
+    if args.n_total < len(args.init):
+        ap.error(
+            f"--n-total ({args.n_total}) must be >= the number of initial points "
+            f"({len(args.init)}: {args.init})"
+        )
 
     torch.manual_seed(args.seed)
     np.random.seed(args.seed)

--- a/scripts/plot_bo_1d.py
+++ b/scripts/plot_bo_1d.py
@@ -1,0 +1,381 @@
+"""Illustrative 1D Bayesian-optimization figures: value-only vs gradient-enhanced GP.
+
+Generates a publication-quality frame (PDF) for every observation added to a 1D
+torsion-scan BO run, for both arms:
+
+  * ``no_gradients`` -- the value-only periodic GP (``SingleTaskGP`` +
+    :func:`bouquet.solver._periodic_covar_module`), and
+  * ``gradients``   -- the gradient-enhanced periodic GP
+    (:func:`bouquet.solver._fit_gradient_gp`), which also conditions on the
+    analytic torsion gradient ``dE/dtheta`` at each point.
+
+Both arms share the same synthetic periodic energy surface and the same two
+initial points, so the only difference between the two sequences is whether the
+surrogate sees gradients. The figures show, frame by frame, that the gradient
+arm collapses its posterior uncertainty and locates the global torsion minimum
+in fewer evaluations.
+
+The surrogate construction (the ``/360`` input normalization, the
+maximize sign-flip, the value standardization, and the matching ``2*pi/std``
+gradient scaling) mirrors :func:`bouquet.solver._select_next_points_botorch`
+exactly, so the plotted GP *is* the acquisition GP. The next point per frame is
+the argmax of LogExpectedImprovement on the plotted dense grid (a 1D analogue of
+the solver's ``optimize_acqf``).
+
+Run:
+    KMP_DUPLICATE_LIB_OK=TRUE PYTHONPATH=. pixi run python scripts/plot_bo_1d.py
+"""
+
+from __future__ import annotations
+
+import argparse
+import math
+from pathlib import Path
+from typing import List, Tuple
+
+import numpy as np
+import torch
+
+import matplotlib
+
+matplotlib.use("Agg")
+import matplotlib.pyplot as plt
+from matplotlib.gridspec import GridSpec
+
+from botorch.acquisition.analytic import LogExpectedImprovement
+from botorch.models import SingleTaskGP
+from botorch.optim.fit import fit_gpytorch_mll_torch
+from gpytorch.mlls import ExactMarginalLogLikelihood
+
+from bouquet.solver import _periodic_covar_module, _fit_gradient_gp
+
+torch.set_default_dtype(torch.float64)
+
+EV2KCAL = 23.060541945  # eV -> kcal/mol
+DEG2RAD = math.pi / 180.0
+
+# ---------------------------------------------------------------------------
+# Synthetic 1D torsion surface (energies in eV, angle in degrees).
+# A tilted three-fold profile: a deep global well near ~240 deg, a shallower
+# secondary well near ~120 deg, and a high barrier near 0/360 deg -- enough
+# structure that the optimizer must explore before committing.
+# ---------------------------------------------------------------------------
+_A3, _A1, _PHI = 0.5, 0.5, 3.5  # eV amplitudes and 1-fold phase (rad)
+
+
+def _raw_energy_rad(t: np.ndarray | float):
+    return _A3 * (1.0 - np.cos(3.0 * t)) + _A1 * (1.0 - np.cos(t - _PHI))
+
+
+# Offset so the global minimum sits at 0 eV (a constant shift; gradients unchanged).
+_FINE = np.linspace(0.0, 2.0 * math.pi, 20001)
+_EMIN = float(_raw_energy_rad(_FINE).min())
+
+
+def true_energy(deg: np.ndarray | float):
+    """Relative torsion energy (eV) at angle ``deg`` (degrees)."""
+    t = np.asarray(deg, dtype=float) * DEG2RAD
+    return _raw_energy_rad(t) - _EMIN
+
+
+def true_gradient(deg: np.ndarray | float):
+    """Analytic dE/dtheta (eV/rad) -- the signal the gradient arm conditions on."""
+    t = np.asarray(deg, dtype=float) * DEG2RAD
+    return _A3 * 3.0 * np.sin(3.0 * t) + _A1 * np.sin(t - _PHI)
+
+
+# ---------------------------------------------------------------------------
+# Surrogate fit + dense-grid posterior + acquisition (mirrors the solver).
+# ---------------------------------------------------------------------------
+class ArmResult:
+    """Posterior and acquisition on the plotting grid for one BO frame."""
+
+    def __init__(self, mean_eV, sigma_eV, ei, next_deg, best_eV):
+        self.mean_eV = mean_eV  # (M,) posterior mean energy, eV
+        self.sigma_eV = sigma_eV  # (M,) posterior std, eV
+        self.ei = ei  # (M,) expected improvement (acq.), arbitrary scale
+        self.next_deg = next_deg  # argmax-EI angle (next point to evaluate)
+        self.best_eV = best_eV  # best observed energy so far, eV
+
+
+def fit_arm(
+    obs_deg: np.ndarray,
+    obs_eV: np.ndarray,
+    obs_grad: np.ndarray,
+    use_gradients: bool,
+    grid_deg: np.ndarray,
+) -> ArmResult:
+    """Fit the (value-only or gradient-enhanced) GP and evaluate it on ``grid_deg``.
+
+    The standardization here is identical to
+    ``bouquet.solver._select_next_points_botorch`` so the posterior we plot is the
+    one acquisition actually sees; we then map it back to physical energy for the
+    figure.
+    """
+    train_X = torch.tensor(obs_deg, dtype=torch.float64).unsqueeze(-1)  # (n,1) deg
+    raw_y = torch.tensor(obs_eV, dtype=torch.float64)  # (n,) relative eV
+    x = train_X / 360.0
+
+    # maximize sign-flip + energy clamp (inactive here; mirrors the solver)
+    energy_cap = 2.0 + torch.log10(torch.clamp(raw_y, min=1.0))
+    neg = (-1.0 * torch.minimum(raw_y, energy_cap)).unsqueeze(-1)  # (n,1)
+    neg_mean = neg.mean(dim=0, keepdim=True)
+    y_std = neg.std(dim=0, keepdim=True)
+    y_std = torch.where(y_std >= 1e-9, y_std, torch.ones_like(y_std))
+    train_y = (neg - neg_mean) / y_std  # standardized, "maximize" sense
+
+    if use_gradients:
+        grad = torch.tensor(obs_grad, dtype=torch.float64).unsqueeze(-1)  # (n,1) eV/rad
+        gp = _fit_gradient_gp(x, train_y, raw_y, energy_cap, grad, y_std)
+    else:
+        gp = SingleTaskGP(x, train_y, covar_module=_periodic_covar_module(1))
+        mll = ExactMarginalLogLikelihood(gp.likelihood, gp)
+        fit_gpytorch_mll_torch(
+            mll, step_limit=200, optimizer=lambda p: torch.optim.Adam(p, lr=0.01)
+        )
+    gp.eval()
+
+    gx = torch.tensor(grid_deg / 360.0, dtype=torch.float64).unsqueeze(-1)  # (M,1)
+    with torch.no_grad():
+        post = gp.posterior(gx)
+        m_std = post.mean.reshape(-1)
+        sd_std = post.variance.clamp_min(0.0).sqrt().reshape(-1)
+
+    ys = float(y_std)
+    nm = float(neg_mean)
+    # invert standardization + sign flip: E = -(m_std*std + mean)
+    mean_eV = -(m_std * ys + nm)
+    sigma_eV = sd_std * ys
+
+    # LogExpectedImprovement on the same grid -> exp -> argmax = next point.
+    acqf = LogExpectedImprovement(gp, best_f=train_y.max(), maximize=True)
+    with torch.no_grad():
+        log_ei = acqf(gx.unsqueeze(1))  # (M,1,1) -> (M,)
+    ei = log_ei.exp()
+    next_deg = float(grid_deg[int(ei.argmax())])
+
+    return ArmResult(
+        mean_eV=mean_eV.numpy(),
+        sigma_eV=sigma_eV.numpy(),
+        ei=ei.numpy(),
+        next_deg=next_deg,
+        best_eV=float(raw_y.min()),
+    )
+
+
+# ---------------------------------------------------------------------------
+# Plotting
+# ---------------------------------------------------------------------------
+def _style():
+    plt.rcParams.update(
+        {
+            "figure.dpi": 150,
+            "savefig.dpi": 150,
+            "font.size": 12,
+            "axes.titlesize": 13,
+            "axes.labelsize": 12,
+            "axes.spines.top": False,
+            "axes.spines.right": False,
+            "axes.linewidth": 0.9,
+            "lines.linewidth": 2.0,
+            "legend.frameon": False,
+            "legend.fontsize": 10,
+            "pdf.fonttype": 42,  # editable text in Illustrator/Inkscape
+            "ps.fonttype": 42,
+        }
+    )
+
+
+C_TRUE = "#888888"
+C_MEAN = "#1f77b4"
+C_BAND = "#1f77b4"
+C_OBS = "#111111"
+C_NEXT = "#d62728"
+C_ACQ = "#2ca02c"
+
+
+def plot_frame(
+    grid_deg: np.ndarray,
+    true_eV: np.ndarray,
+    res: ArmResult,
+    obs_deg: np.ndarray,
+    obs_eV: np.ndarray,
+    obs_grad: np.ndarray,
+    use_gradients: bool,
+    n_obs: int,
+    n_init: int,
+    ylim: tuple[float, float],
+    out_path: Path,
+    show_next: bool = True,
+):
+    """Render one BO frame (posterior + acquisition) to a PDF."""
+    fig = plt.figure(figsize=(7.0, 5.2), constrained_layout=True)
+    gs = GridSpec(2, 1, height_ratios=[3.0, 1.0], figure=fig, hspace=0.05)
+    ax = fig.add_subplot(gs[0])
+    axa = fig.add_subplot(gs[1], sharex=ax)
+
+    true_k = true_eV * EV2KCAL
+    mean_k = res.mean_eV * EV2KCAL
+    sig_k = res.sigma_eV * EV2KCAL
+    obs_k = obs_eV * EV2KCAL
+
+    # --- top: surrogate over the true surface ---
+    ax.fill_between(
+        grid_deg,
+        mean_k - 2.0 * sig_k,
+        mean_k + 2.0 * sig_k,
+        color=C_BAND,
+        alpha=0.18,
+        lw=0,
+        label="GP 95% CI",
+    )
+    ax.plot(grid_deg, true_k, color=C_TRUE, ls="--", lw=1.8, label="True energy")
+    ax.plot(grid_deg, mean_k, color=C_MEAN, label="GP mean")
+
+    # observations; split initial vs BO-acquired for a subtle visual cue
+    init_mask = np.arange(len(obs_deg)) < n_init
+    ax.scatter(
+        obs_deg[init_mask], obs_k[init_mask], s=55, color=C_OBS, zorder=5,
+        edgecolors="white", linewidths=0.6, label="Initial points",
+    )
+    if (~init_mask).any():
+        ax.scatter(
+            obs_deg[~init_mask], obs_k[~init_mask], s=55, color=C_OBS, zorder=5,
+            marker="o", edgecolors="white", linewidths=0.6, label="Acquired points",
+        )
+
+    # gradient ticks: short segments with the observed dE/dtheta slope
+    if use_gradients:
+        dx = 11.0  # half-length of the slope tick, in degrees
+        for xd, yk, g in zip(obs_deg, obs_k, obs_grad):
+            slope_k_per_deg = g * EV2KCAL * DEG2RAD  # eV/rad -> kcal/mol per deg
+            ax.plot(
+                [xd - dx, xd + dx],
+                [yk - slope_k_per_deg * dx, yk + slope_k_per_deg * dx],
+                color=C_NEXT, lw=1.6, alpha=0.85, zorder=4,
+            )
+
+    if show_next:
+        ax.axvline(res.next_deg, color=C_NEXT, ls=":", lw=1.6, alpha=0.9)
+
+    ax.set_ylim(*ylim)
+    ax.set_xlim(0, 360)
+    ax.set_ylabel("Relative energy (kcal/mol)")
+    ax.set_xticks(np.arange(0, 361, 60))
+    plt.setp(ax.get_xticklabels(), visible=False)
+
+    arm = "Gradient-enhanced GP" if use_gradients else "Value-only GP"
+    ax.set_title(f"{arm}   —   {n_obs} evaluations   (best: {res.best_eV*EV2KCAL:.2f} kcal/mol)")
+    ax.legend(loc="upper center", ncol=3, columnspacing=1.2, handletextpad=0.5)
+
+    # --- bottom: acquisition ---
+    ei = res.ei
+    ei_plot = ei / ei.max() if ei.max() > 0 else ei
+    axa.fill_between(grid_deg, 0, ei_plot, color=C_ACQ, alpha=0.30, lw=0)
+    axa.plot(grid_deg, ei_plot, color=C_ACQ, lw=1.6)
+    if show_next:
+        axa.axvline(res.next_deg, color=C_NEXT, ls=":", lw=1.6, alpha=0.9)
+        axa.scatter([res.next_deg], [1.0], marker="v", s=60, color=C_NEXT,
+                    zorder=6, clip_on=False, label="Next point")
+        axa.legend(loc="upper right")
+    axa.set_ylim(0, 1.08)
+    axa.set_yticks([])
+    axa.set_xlim(0, 360)
+    axa.set_xlabel("Dihedral angle (degrees)")
+    axa.set_ylabel("EI", rotation=0, labelpad=14, va="center")
+    axa.set_xticks(np.arange(0, 361, 60))
+
+    fig.savefig(out_path)
+    plt.close(fig)
+
+
+# ---------------------------------------------------------------------------
+# BO driver
+# ---------------------------------------------------------------------------
+def run_arm(
+    use_gradients: bool,
+    init_deg: list[float],
+    n_total: int,
+    grid_deg: np.ndarray,
+    true_eV: np.ndarray,
+    ylim: tuple[float, float],
+    out_dir: Path,
+) -> list[tuple[int, float]]:
+    """Run one BO arm, write a frame per evaluation, return (n_obs, best_eV) history."""
+    out_dir.mkdir(parents=True, exist_ok=True)
+    n_init = len(init_deg)
+
+    obs_deg = np.array(init_deg, dtype=float)
+    obs_eV = true_energy(obs_deg)
+    obs_grad = true_gradient(obs_deg)
+
+    history: list[tuple[int, float]] = []
+    while True:
+        n = len(obs_deg)
+        res = fit_arm(obs_deg, obs_eV, obs_grad, use_gradients, grid_deg)
+        history.append((n, res.best_eV))
+        last = n >= n_total
+        plot_frame(
+            grid_deg, true_eV, res, obs_deg, obs_eV, obs_grad,
+            use_gradients, n, n_init, ylim,
+            out_dir / f"frame_{n:02d}.pdf",
+            show_next=not last,
+        )
+        if last:
+            break
+        # evaluate the proposed point and append (true energy + analytic gradient)
+        nd = res.next_deg
+        obs_deg = np.append(obs_deg, nd)
+        obs_eV = np.append(obs_eV, true_energy(nd))
+        obs_grad = np.append(obs_grad, true_gradient(nd))
+
+    return history
+
+
+def main():
+    ap = argparse.ArgumentParser(description=__doc__)
+    ap.add_argument("--out", default="figures/bo_1d", help="output directory")
+    ap.add_argument("--n-total", type=int, default=20, help="total evaluations per arm")
+    ap.add_argument(
+        "--init", type=float, nargs="+", default=[60.0, 150.0],
+        help="initial dihedral angles (degrees); both arms share these",
+    )
+    ap.add_argument("--seed", type=int, default=0)
+    args = ap.parse_args()
+
+    torch.manual_seed(args.seed)
+    np.random.seed(args.seed)
+    _style()
+
+    grid_deg = np.linspace(0.0, 360.0, 1000, endpoint=False)
+    true_eV = true_energy(grid_deg)
+    true_k = true_eV * EV2KCAL
+    ylim = (-1.5, float(true_k.max()) + 4.0)
+
+    out_root = Path(args.out)
+    print(f"Global minimum near {grid_deg[int(true_eV.argmin())]:.0f} deg "
+          f"(0.00 kcal/mol); initial points at {args.init} deg\n")
+
+    hist = {}
+    for use_grad, name in [(False, "no_gradients"), (True, "gradients")]:
+        # reseed so the two arms are paired (same acquisition-optimizer randomness)
+        torch.manual_seed(args.seed)
+        np.random.seed(args.seed)
+        hist[name] = run_arm(
+            use_grad, list(args.init), args.n_total, grid_deg, true_eV, ylim,
+            out_root / name,
+        )
+        n_frames = len(hist[name])
+        print(f"[{name}] wrote {n_frames} frames to {out_root / name}")
+
+    # convergence summary: first eval within 1 kcal/mol of the global minimum
+    thr_eV = 1.0 / EV2KCAL
+    print("\nCalls to within 1 kcal/mol of the global minimum:")
+    for name in ("no_gradients", "gradients"):
+        reached = next((n for n, b in hist[name] if b <= thr_eV), None)
+        msg = f"{reached} evaluations" if reached else f"not within budget ({args.n_total})"
+        print(f"  {name:13s}: {msg}")
+
+
+if __name__ == "__main__":
+    main()

--- a/scripts/plot_bo_2d.py
+++ b/scripts/plot_bo_2d.py
@@ -1,0 +1,393 @@
+"""Illustrative 2D Bayesian-optimization figures: value-only vs gradient-enhanced GP.
+
+The 2D analogue of ``scripts/plot_bo_1d.py``. Two coupled torsions span a
+periodic energy surface; for every observation added to a BO run we render a
+2x2 frame (PDF) -- the true surface, the GP posterior mean, the posterior
+uncertainty, and the acquisition function -- for both arms:
+
+  * ``no_gradients`` -- the value-only periodic GP (``SingleTaskGP`` +
+    :func:`bouquet.solver._periodic_covar_module`), and
+  * ``gradients``   -- the gradient-enhanced periodic GP
+    (:func:`bouquet.solver._fit_gradient_gp`), which also conditions on the
+    analytic torsion gradient ``(dE/dtheta_1, dE/dtheta_2)`` at each point. That
+    gradient is a 2D vector, drawn as a downhill arrow at each observation.
+
+Both arms share the same surface and the same initial points, so the only
+difference is whether the surrogate sees gradients. The figures show the
+gradient arm collapsing its uncertainty across the whole torus -- not just at
+the sampled points -- and locating the global basin in far fewer evaluations.
+
+The surrogate construction mirrors
+``bouquet.solver._select_next_points_botorch`` exactly (the ``/360``
+normalization, the maximize sign-flip, the value standardization, and the
+matching ``2*pi/std`` gradient scaling), so the plotted GP *is* the acquisition
+GP. The next point is the argmax of LogExpectedImprovement on the plotted grid.
+
+Run:
+    KMP_DUPLICATE_LIB_OK=TRUE PYTHONPATH=. pixi run python scripts/plot_bo_2d.py
+"""
+
+from __future__ import annotations
+
+import argparse
+import math
+from pathlib import Path
+from typing import List, Tuple
+
+import numpy as np
+import torch
+
+import matplotlib
+
+matplotlib.use("Agg")
+import matplotlib.pyplot as plt
+
+from botorch.acquisition.analytic import LogExpectedImprovement
+from botorch.models import SingleTaskGP
+from botorch.optim.fit import fit_gpytorch_mll_torch
+from gpytorch.mlls import ExactMarginalLogLikelihood
+
+from bouquet.solver import _periodic_covar_module, _fit_gradient_gp
+
+torch.set_default_dtype(torch.float64)
+
+EV2KCAL = 23.060541945  # eV -> kcal/mol
+DEG2RAD = math.pi / 180.0
+
+# ---------------------------------------------------------------------------
+# Synthetic 2D torsion surface (energies in eV, angles in degrees).
+# A sum of periodic (von Mises-like) wells on the torus: a deep global basin
+# plus two shallower competing basins, so the optimizer must explore in 2D
+# before committing. Smooth and analytically differentiable everywhere.
+# ---------------------------------------------------------------------------
+_KAPPA = 0.8
+# (center_theta1_deg, center_theta2_deg, depth_eV)
+_WELLS = [
+    (250.0, 280.0, 0.060),  # global basin (deepest)
+    (90.0, 110.0, 0.045),   # secondary
+    (340.0, 30.0, 0.038),   # tertiary
+]
+
+
+def _raw_energy_rad(t1, t2):
+    e = np.zeros(np.broadcast(t1, t2).shape)
+    for c1, c2, d in _WELLS:
+        e = e - d * np.exp(_KAPPA * (np.cos(t1 - c1 * DEG2RAD) + np.cos(t2 - c2 * DEG2RAD)))
+    return e
+
+
+# Offset so the global minimum sits at 0 eV (constant shift; gradients unchanged).
+_g = np.linspace(0.0, 2.0 * math.pi, 721)
+_T1, _T2 = np.meshgrid(_g, _g, indexing="ij")
+_EMIN = float(_raw_energy_rad(_T1, _T2).min())
+
+
+def true_energy(deg1, deg2):
+    """Relative energy (eV) at angles (deg1, deg2) in degrees."""
+    t1 = np.asarray(deg1, dtype=float) * DEG2RAD
+    t2 = np.asarray(deg2, dtype=float) * DEG2RAD
+    return _raw_energy_rad(t1, t2) - _EMIN
+
+
+def true_gradient(deg1, deg2):
+    """Analytic (dE/dtheta_1, dE/dtheta_2) in eV/rad -- the gradient signal."""
+    t1 = np.asarray(deg1, dtype=float) * DEG2RAD
+    t2 = np.asarray(deg2, dtype=float) * DEG2RAD
+    g1 = np.zeros(np.broadcast(t1, t2).shape)
+    g2 = np.zeros(np.broadcast(t1, t2).shape)
+    for c1, c2, d in _WELLS:
+        w = d * np.exp(_KAPPA * (np.cos(t1 - c1 * DEG2RAD) + np.cos(t2 - c2 * DEG2RAD)))
+        g1 = g1 + w * _KAPPA * np.sin(t1 - c1 * DEG2RAD)
+        g2 = g2 + w * _KAPPA * np.sin(t2 - c2 * DEG2RAD)
+    return np.stack([g1, g2], axis=-1)
+
+
+# ---------------------------------------------------------------------------
+# Surrogate fit + grid posterior + acquisition (mirrors the solver, d=2).
+# ---------------------------------------------------------------------------
+class ArmResult:
+    def __init__(self, mean_eV, sigma_eV, ei, next_deg, best_eV):
+        self.mean_eV = mean_eV  # (M,) posterior mean energy, eV
+        self.sigma_eV = sigma_eV  # (M,) posterior std, eV
+        self.ei = ei  # (M,) expected improvement, arbitrary scale
+        self.next_deg = next_deg  # (2,) argmax-EI angle, the next point
+        self.best_eV = best_eV  # best observed energy so far, eV
+
+
+def fit_arm(
+    obs_deg: np.ndarray,  # (n, 2)
+    obs_eV: np.ndarray,  # (n,)
+    obs_grad: np.ndarray,  # (n, 2) eV/rad
+    use_gradients: bool,
+    query_deg: np.ndarray,  # (M, 2)
+) -> ArmResult:
+    """Fit the GP and evaluate posterior + acquisition at ``query_deg``.
+
+    Standardization is identical to ``_select_next_points_botorch`` so the
+    plotted posterior is the acquisition GP; we then map it back to energy.
+    """
+    train_X = torch.tensor(obs_deg, dtype=torch.float64)  # (n, 2) deg
+    raw_y = torch.tensor(obs_eV, dtype=torch.float64)  # (n,) eV
+    x = train_X / 360.0
+
+    energy_cap = 2.0 + torch.log10(torch.clamp(raw_y, min=1.0))
+    neg = (-1.0 * torch.minimum(raw_y, energy_cap)).unsqueeze(-1)  # (n,1)
+    neg_mean = neg.mean(dim=0, keepdim=True)
+    y_std = neg.std(dim=0, keepdim=True)
+    y_std = torch.where(y_std >= 1e-9, y_std, torch.ones_like(y_std))
+    train_y = (neg - neg_mean) / y_std
+
+    if use_gradients:
+        grad = torch.tensor(obs_grad, dtype=torch.float64)  # (n, 2) eV/rad
+        gp = _fit_gradient_gp(x, train_y, raw_y, energy_cap, grad, y_std)
+    else:
+        gp = SingleTaskGP(x, train_y, covar_module=_periodic_covar_module(2))
+        mll = ExactMarginalLogLikelihood(gp.likelihood, gp)
+        fit_gpytorch_mll_torch(
+            mll, step_limit=200, optimizer=lambda p: torch.optim.Adam(p, lr=0.01)
+        )
+    gp.eval()
+
+    # Batch query points as (M, 1, d) so each is its own q=1 posterior -- avoids
+    # forming the full M x M covariance (essential for a dense 2D grid).
+    qx = torch.tensor(query_deg / 360.0, dtype=torch.float64).unsqueeze(1)  # (M,1,2)
+    with torch.no_grad():
+        post = gp.posterior(qx)
+        m_std = post.mean.reshape(-1)
+        sd_std = post.variance.clamp_min(0.0).sqrt().reshape(-1)
+
+    ys = float(y_std)
+    nm = float(neg_mean)
+    mean_eV = -(m_std * ys + nm)  # invert standardization + sign flip
+    sigma_eV = sd_std * ys
+
+    acqf = LogExpectedImprovement(gp, best_f=train_y.max(), maximize=True)
+    with torch.no_grad():
+        log_ei = acqf(qx)  # (M,1,2) -> (M,)
+    ei = log_ei.exp()
+    next_deg = query_deg[int(ei.argmax())].copy()
+
+    return ArmResult(
+        mean_eV=mean_eV.numpy(),
+        sigma_eV=sigma_eV.numpy(),
+        ei=ei.numpy(),
+        next_deg=next_deg,
+        best_eV=float(raw_y.min()),
+    )
+
+
+# ---------------------------------------------------------------------------
+# Plotting
+# ---------------------------------------------------------------------------
+def _style():
+    plt.rcParams.update(
+        {
+            "figure.dpi": 150,
+            "savefig.dpi": 150,
+            "font.size": 11,
+            "axes.titlesize": 12,
+            "axes.labelsize": 11,
+            "axes.linewidth": 0.9,
+            "legend.frameon": False,
+            "legend.fontsize": 9,
+            "pdf.fonttype": 42,
+            "ps.fonttype": 42,
+        }
+    )
+
+
+C_OBS = "#111111"
+C_NEXT = "#d62728"
+C_GRAD = "#d62728"
+
+
+def _overlay_points(ax, obs_deg, n_init, next_deg=None, star_color=C_NEXT):
+    init = obs_deg[:n_init]
+    acq = obs_deg[n_init:]
+    ax.scatter(init[:, 0], init[:, 1], s=45, c=C_OBS, edgecolors="white",
+               linewidths=0.7, zorder=5)
+    if len(acq):
+        ax.scatter(acq[:, 0], acq[:, 1], s=45, c=C_OBS, marker="o",
+                   edgecolors="white", linewidths=0.7, zorder=5)
+    if next_deg is not None:
+        ax.scatter([next_deg[0]], [next_deg[1]], s=180, marker="*",
+                   c=star_color, edgecolors="white", linewidths=0.8, zorder=6)
+
+
+def _axfmt(ax, xlabel=True, ylabel=True):
+    ax.set_xlim(0, 360)
+    ax.set_ylim(0, 360)
+    ax.set_xticks(np.arange(0, 361, 90))
+    ax.set_yticks(np.arange(0, 361, 90))
+    ax.set_aspect("equal")
+    if xlabel:
+        ax.set_xlabel(r"Dihedral $\theta_1$ (degrees)")
+    if ylabel:
+        ax.set_ylabel(r"Dihedral $\theta_2$ (degrees)")
+
+
+def plot_frame(
+    T1, T2, true_k, res, obs_deg, obs_grad, use_gradients, n_obs, n_init,
+    e_levels, sigma_vmax, grad_scale, out_path, show_next=True,
+):
+    """Render one 2x2 BO frame to a PDF."""
+    M = T1.shape
+    mean_k = (res.mean_eV * EV2KCAL).reshape(M)
+    sig_k = (res.sigma_eV * EV2KCAL).reshape(M)
+    ei = res.ei.reshape(M)
+    nd = res.next_deg if show_next else None
+
+    fig, axes = plt.subplots(2, 2, figsize=(9.2, 8.6), constrained_layout=True)
+    (ax_t, ax_m), (ax_s, ax_a) = axes
+
+    arm = "Gradient-enhanced GP" if use_gradients else "Value-only GP"
+    fig.suptitle(
+        f"{arm}   —   {n_obs} evaluations   "
+        f"(best: {res.best_eV * EV2KCAL:.2f} kcal/mol)",
+        fontsize=14,
+    )
+
+    # --- true surface ---
+    cf = ax_t.contourf(T1, T2, true_k, levels=e_levels, cmap="viridis")
+    ax_t.contour(T1, T2, true_k, levels=e_levels, colors="white",
+                 linewidths=0.3, alpha=0.4)
+    ax_t.set_title("True energy surface")
+    if use_gradients:
+        # downhill arrows (-gradient) at each observation
+        g = obs_grad  # (n,2) eV/rad
+        ax_t.quiver(
+            obs_deg[:, 0], obs_deg[:, 1], -g[:, 0], -g[:, 1],
+            color=C_GRAD, angles="xy", scale_units="xy", scale=grad_scale,
+            width=0.006, zorder=4,
+        )
+    _overlay_points(ax_t, obs_deg, n_init, nd)
+    _axfmt(ax_t, xlabel=False)
+    fig.colorbar(cf, ax=ax_t, shrink=0.85, label="kcal/mol")
+
+    # --- posterior mean ---
+    cf = ax_m.contourf(T1, T2, mean_k, levels=e_levels, cmap="viridis", extend="both")
+    ax_m.contour(T1, T2, mean_k, levels=e_levels, colors="white",
+                 linewidths=0.3, alpha=0.4)
+    ax_m.set_title("GP posterior mean")
+    _overlay_points(ax_m, obs_deg, n_init, nd)
+    _axfmt(ax_m, xlabel=False, ylabel=False)
+    fig.colorbar(cf, ax=ax_m, shrink=0.85, label="kcal/mol")
+
+    # --- posterior uncertainty ---
+    cf = ax_s.contourf(T1, T2, sig_k, levels=np.linspace(0, sigma_vmax, 21),
+                       cmap="magma", extend="max")
+    ax_s.set_title(r"GP uncertainty ($\sigma$)")
+    _overlay_points(ax_s, obs_deg, n_init, nd)
+    _axfmt(ax_s)
+    fig.colorbar(cf, ax=ax_s, shrink=0.85, label="kcal/mol")
+
+    # --- acquisition ---
+    ei_plot = ei / ei.max() if ei.max() > 0 else ei
+    cf = ax_a.contourf(T1, T2, ei_plot, levels=np.linspace(0, 1, 21), cmap="cividis")
+    ax_a.set_title("Acquisition (EI, per-frame scale)")
+    _overlay_points(ax_a, obs_deg, n_init, nd)
+    _axfmt(ax_a, ylabel=False)
+    fig.colorbar(cf, ax=ax_a, shrink=0.85, label="relative EI")
+
+    fig.savefig(out_path)
+    plt.close(fig)
+
+
+# ---------------------------------------------------------------------------
+# BO driver
+# ---------------------------------------------------------------------------
+def run_arm(
+    use_gradients, init_deg, n_total, T1, T2, query_deg, true_k,
+    e_levels, sigma_vmax, grad_scale, out_dir,
+) -> list[tuple[int, float]]:
+    out_dir.mkdir(parents=True, exist_ok=True)
+    n_init = len(init_deg)
+
+    obs_deg = np.array(init_deg, dtype=float)  # (n,2)
+    obs_eV = true_energy(obs_deg[:, 0], obs_deg[:, 1])
+    obs_grad = true_gradient(obs_deg[:, 0], obs_deg[:, 1])
+
+    history: list[tuple[int, float]] = []
+    while True:
+        n = len(obs_deg)
+        res = fit_arm(obs_deg, obs_eV, obs_grad, use_gradients, query_deg)
+        history.append((n, res.best_eV))
+        last = n >= n_total
+        plot_frame(
+            T1, T2, true_k, res, obs_deg, obs_grad, use_gradients, n, n_init,
+            e_levels, sigma_vmax, grad_scale, out_dir / f"frame_{n:02d}.pdf",
+            show_next=not last,
+        )
+        if last:
+            break
+        nd = res.next_deg
+        obs_deg = np.vstack([obs_deg, nd])
+        obs_eV = np.append(obs_eV, true_energy(nd[0], nd[1]))
+        obs_grad = np.vstack([obs_grad, true_gradient(nd[0], nd[1])])
+
+    return history
+
+
+def main():
+    ap = argparse.ArgumentParser(description=__doc__)
+    ap.add_argument("--out", default="figures/bo_2d")
+    ap.add_argument("--n-total", type=int, default=24, help="total evaluations per arm")
+    ap.add_argument("--n-grid", type=int, default=80, help="contour grid resolution per axis")
+    ap.add_argument(
+        "--init", type=float, nargs="+", default=[30, 60, 150, 40, 60, 300],
+        help="flat list of initial (theta1, theta2) pairs in degrees; both arms share these",
+    )
+    ap.add_argument("--seed", type=int, default=0)
+    args = ap.parse_args()
+
+    init = np.array(args.init, dtype=float).reshape(-1, 2)
+    torch.manual_seed(args.seed)
+    np.random.seed(args.seed)
+    _style()
+
+    # dense grid for contours / argmax acquisition
+    g = np.linspace(0.0, 360.0, args.n_grid, endpoint=False)
+    T1, T2 = np.meshgrid(g, g, indexing="ij")
+    query_deg = np.column_stack([T1.ravel(), T2.ravel()])  # (M,2)
+    true_k = true_energy(T1, T2) * EV2KCAL
+    e_levels = np.linspace(0.0, float(true_k.max()), 21)
+
+    gmin = np.unravel_index(int(true_k.argmin()), true_k.shape)
+    print(f"Global minimum near ({g[gmin[0]]:.0f}, {g[gmin[1]]:.0f}) deg; "
+          f"initial points:\n{init}\n")
+
+    # Reference uncertainty scale: max sigma from the initial-only value GP, so the
+    # sigma colorbar is shared across all frames AND both arms (shows the collapse).
+    ref = fit_arm(init, true_energy(init[:, 0], init[:, 1]),
+                  true_gradient(init[:, 0], init[:, 1]), False, query_deg)
+    sigma_vmax = float((ref.sigma_eV * EV2KCAL).max())
+
+    # Quiver scale: map a *typical* (median) gradient magnitude to ~30 deg, so
+    # arrows on the gentle well flanks -- including the initial points -- are
+    # clearly visible. Using the global max instead lets the few steep ridges
+    # dominate the scale and shrinks every other arrow to near-invisibility;
+    # the median is robust to those outliers (steeper points just draw longer).
+    gmag = np.linalg.norm(true_gradient(query_deg[:, 0], query_deg[:, 1]), axis=-1)
+    grad_scale = float(np.median(gmag)) / 30.0
+
+    out_root = Path(args.out)
+    hist = {}
+    for use_grad, name in [(False, "no_gradients"), (True, "gradients")]:
+        torch.manual_seed(args.seed)
+        np.random.seed(args.seed)
+        hist[name] = run_arm(
+            use_grad, [row for row in init], args.n_total, T1, T2, query_deg,
+            true_k, e_levels, sigma_vmax, grad_scale, out_root / name,
+        )
+        print(f"[{name}] wrote {len(hist[name])} frames to {out_root / name}")
+
+    thr_eV = 1.0 / EV2KCAL
+    print("\nCalls to within 1 kcal/mol of the global minimum:")
+    for name in ("no_gradients", "gradients"):
+        reached = next((n for n, b in hist[name] if b <= thr_eV), None)
+        msg = f"{reached} evaluations" if reached else f"not within budget ({args.n_total})"
+        print(f"  {name:13s}: {msg}")
+
+
+if __name__ == "__main__":
+    main()

--- a/scripts/plot_bo_2d.py
+++ b/scripts/plot_bo_2d.py
@@ -164,6 +164,15 @@ def fit_arm(
     acqf = LogExpectedImprovement(gp, best_f=train_y.max(), maximize=True)
     with torch.no_grad():
         log_ei = acqf(qx)  # (M,1,2) -> (M,)
+    # Exclude grid points already evaluated (selected points are grid rows and get
+    # appended verbatim) so EI can't re-propose a sampled point and stall.
+    n_grid = round(math.sqrt(len(query_deg)))
+    step = 360.0 / n_grid
+    d = np.abs(query_deg[:, None, :] - obs_deg[None, :, :])  # (M, n, 2)
+    d = np.minimum(d, 360.0 - d)  # periodic per axis
+    sampled = (d < step / 2).all(axis=2).any(axis=1)  # (M,)
+    if not sampled.all():  # keep at least one candidate if every grid point is taken
+        log_ei = log_ei.masked_fill(torch.from_numpy(sampled), float("-inf"))
     ei = log_ei.exp()
     next_deg = query_deg[int(ei.argmax())].copy()
 
@@ -340,6 +349,17 @@ def main():
     ap.add_argument("--seed", type=int, default=0)
     args = ap.parse_args()
 
+    if len(args.init) % 2 != 0:
+        ap.error(
+            f"--init must be a flat list of (theta1, theta2) pairs (even length); "
+            f"got {len(args.init)} values: {args.init}"
+        )
+    num_pairs = len(args.init) // 2
+    if args.n_total < num_pairs:
+        ap.error(
+            f"--n-total ({args.n_total}) must be >= the number of initial pairs "
+            f"({num_pairs}) from --init"
+        )
     init = np.array(args.init, dtype=float).reshape(-1, 2)
     torch.manual_seed(args.seed)
     np.random.seed(args.seed)

--- a/scripts/sweep_common.py
+++ b/scripts/sweep_common.py
@@ -17,10 +17,18 @@ Configurations are passed as ``{label: full_extra_cli_args}`` (each arm fully
 specifies its own flags, including ``--priors`` where relevant), so ``run_one``
 is configuration-agnostic.
 
-Paired comparisons are by (molecule, seed): bouquet now seeds every RNG
-(numpy + torch) from ``--seed``, so the arms share their randomness at a fixed
-seed and differencing per (name, seed) cancels the shared Bayesian-optimization
+Paired comparisons are by (molecule, seed): bouquet seeds every RNG (numpy +
+torch) from ``--seed``, so the arms share their randomness at a fixed seed and
+differencing per (name, seed) cancels much of the shared Bayesian-optimization
 noise (common random numbers), isolating the configuration effect.
+
+Caveat: common random numbers only hold *exactly* when runs are deterministic.
+Multi-threaded BLAS (the default) has non-deterministic reduction order, and the
+chaotic BO search amplifies that ~1e-6 noise into different basins -- two
+identical runs can finish ~0.02 eV apart. That ~0.02 eV is the paired-comparison
+noise floor unless you pass ``--single-thread`` (bit-reproducible, slower). For a
+clean isolation of a single configuration knob, run single-threaded; for a broad
+sweep, rely on the per-molecule-mean statistics in ``analyze`` to average it out.
 """
 
 import argparse
@@ -83,17 +91,66 @@ _EVAL_RE = re.compile(
 # ---------------------------------------------------------------------------
 
 
-def subprocess_run(cmd: List[str]) -> Tuple[str, int]:
+def subprocess_run(
+    cmd: List[str], timeout: Optional[float] = None, env: Optional[dict] = None
+) -> Tuple[str, int]:
     """Run a command, returning (combined stdout+stderr, returncode).
 
-    Logging may go to either stream, so both are combined for parsing.
+    Logging may go to either stream, so both are combined for parsing. If
+    ``timeout`` (seconds) is given and exceeded, the child is killed and a
+    non-zero return code (124, matching coreutils ``timeout``) is returned along
+    with whatever output was captured before the kill -- some molecules (large,
+    very flexible) can run effectively forever, so the sweep must not block on
+    one trial. ``env`` overrides the child environment (e.g. pinning BLAS threads
+    for run-to-run determinism); None inherits the parent's.
     """
     import subprocess
 
-    result = subprocess.run(
-        cmd, capture_output=True, text=True, stdin=subprocess.DEVNULL
+    def _text(x) -> str:  # TimeoutExpired output is sometimes bytes even w/ text=True
+        if x is None:
+            return ""
+        return x.decode("utf-8", "replace") if isinstance(x, bytes) else x
+
+    try:
+        result = subprocess.run(
+            cmd, capture_output=True, text=True, stdin=subprocess.DEVNULL,
+            timeout=timeout, env=env,
+        )
+        return result.stdout + "\n" + result.stderr, result.returncode
+    except subprocess.TimeoutExpired as e:
+        out = _text(e.stdout) + "\n" + _text(e.stderr)
+        return out + f"\n[sweep] trial killed after {timeout:g}s timeout\n", 124
+
+
+def single_thread_env() -> dict:
+    """Parent environment with BLAS/OpenMP thread counts pinned to 1.
+
+    The gradient-GP fit and the acquisition optimizer use multi-threaded BLAS,
+    whose reduction order is not deterministic run-to-run; the chaotic BO search
+    amplifies the resulting ~1e-6 noise into different basins (two identical runs
+    can finish ~0.02 eV apart). Pinning to one thread makes a run bit-reproducible
+    from its seed, which is what the paired (common-random-number) comparison needs
+    to actually cancel noise between arms. The trade-off is slower per-trial fits.
+    """
+    import os
+
+    return dict(
+        os.environ,
+        OMP_NUM_THREADS="1",
+        MKL_NUM_THREADS="1",
+        OPENBLAS_NUM_THREADS="1",
+        NUMEXPR_NUM_THREADS="1",
     )
-    return result.stdout + "\n" + result.stderr, result.returncode
+
+
+def require_single_surface(energy: Optional[str], optimizer: Optional[str]) -> None:
+    """Exit unless ``energy == optimizer``. ``--use-gradients`` with ``--relax``
+    needs a single surface so the projected torsion gradient equals dE*/dtheta at the
+    constrained minimum of the energy calculator (see bouquet.cli)."""
+    if energy != optimizer:
+        sys.exit(f"--use-gradients with --relax requires --energy == --optimizer "
+                 f"(got {energy} / {optimizer}); the torsion gradient is only "
+                 "dE*/dtheta at a constrained minimum of the energy calculator.")
 
 
 def parse_trajectory(log_text: str) -> List[Tuple[str, float]]:
@@ -141,12 +198,18 @@ def run_one(
     seed: int,
     energy_method: Optional[str],
     optimizer_method: Optional[str],
+    timeout: Optional[float] = None,
+    fail_log_dir: Optional[Path] = None,
+    env: Optional[dict] = None,
 ) -> Tuple[Dict, List[Dict]]:
     """Run a single (config, molecule, seed) trial.
 
     Returns ``(summary_row, traj_rows)``: the tidy summary dict and the
     per-evaluation trajectory rows (running best-so-far) for this trial.
     ``extra_args`` fully specifies the arm (including ``--priors`` if needed).
+    A trial exceeding ``timeout`` seconds is killed and recorded as a failure.
+    On any failure, the captured stdout+stderr is written under ``fail_log_dir``
+    (if given) so crashes can be told apart from timeouts after the fact.
     """
     cmd = [
         sys.executable, "-m", "bouquet.cli",
@@ -162,7 +225,7 @@ def run_one(
     if optimizer_method:
         cmd += ["--optimizer", optimizer_method]
 
-    proc, returncode = subprocess_run(cmd)
+    proc, returncode = subprocess_run(cmd, timeout=timeout, env=env)
     parsed = parse_log_output(proc)
     # Mirror batch.py: a trial only counts as successful when the process exited
     # cleanly AND a best step was parsed from the log.
@@ -180,6 +243,17 @@ def run_one(
         "e_e0_constrained": parsed["e_e0_constrained"] if ok else "",
         "e_e0_unconstrained": parsed["e_e0_unconstrained"] if ok else "",
     }
+    # Persist the log of a failed trial for diagnosis (timeout vs. crash vs. a
+    # ValueError like the gradient single-surface check). Unique filename per
+    # trial key, so concurrent workers never collide -- no lock needed.
+    if not ok and fail_log_dir is not None:
+        fail_log_dir.mkdir(parents=True, exist_ok=True)
+        log_path = fail_log_dir / f"{config}_{_safe_filename(name)}_seed{seed}.log"
+        with open(log_path, "w") as f:
+            f.write(f"# cmd: {' '.join(cmd)}\n# returncode: {returncode}"
+                    f"{'  (124 = timeout)' if returncode == 124 else ''}\n\n")
+            f.write(proc)
+
     # Only emit trajectory rows for cleanly-exited runs; a crashed process may
     # have produced a partial/misleading log.
     traj_rows = (
@@ -188,6 +262,63 @@ def run_one(
         else []
     )
     return row, traj_rows
+
+
+def predict_bo_budget(smiles: str) -> Optional[int]:
+    """Predict how many BO steps ``bouquet --auto`` will run for ``smiles``.
+
+    Uses bouquet's own dihedral detection and tiered ``--auto`` budget so the
+    estimate tracks the CLI exactly. Returns ``None`` if it can't be computed
+    (bad SMILES, import failure) -- callers then decline to skip and just run it.
+    Imported lazily so non-gradient sweeps never pay the rdkit/torch import.
+    """
+    try:
+        from bouquet.config import Configuration
+        from bouquet.setup import detect_dihedrals, get_initial_structure
+
+        _, mol = get_initial_structure(smiles)
+        d = len(detect_dihedrals(mol))
+        cfg = Configuration(smiles=smiles, auto_steps=True)
+        return cfg.compute_auto_steps(d, cfg.init_steps)
+    except Exception:
+        return None
+
+
+def _flag_int(extra_args: List[str], flag: str) -> Optional[int]:
+    """The int value following ``flag`` in a CLI-arg list, or None if the flag is
+    absent or its value can't be parsed."""
+    if flag in extra_args:
+        try:
+            return int(extra_args[extra_args.index(flag) + 1])
+        except (IndexError, ValueError):
+            return None
+    return None
+
+
+def arm_gradient_steps(extra_args: List[str], budget: int) -> int:
+    """Number of BO steps this arm would run the *gradient-enhanced* GP for, given
+    a molecule's BO ``budget``.
+
+    0 if the arm is value-only. A ``--gradient-steps N`` cap (e.g. the hybrid arm)
+    limits it to ``min(N, budget)``; an uncapped ``--use-gradients`` arm runs the
+    gradient GP for the whole ``budget``. This is what the predictive skip tests
+    against, so capped arms are never skipped for being long.
+    """
+    if "--use-gradients" not in extra_args:
+        return 0
+    cap = _flag_int(extra_args, "--gradient-steps")
+    return min(cap, budget) if cap and cap > 0 else budget
+
+
+def arm_freezes_hypers(extra_args: List[str]) -> bool:
+    """True if the gradient arm uses the freeze schedule, so its whole-run gradient
+    GP is tractable and the predictive skip should leave it in.
+
+    Freezing is bouquet's default (``Configuration.grad_refit_dense_until`` defaults
+    to 20), so a bare ``--use-gradients`` arm freezes and is exempt; only an explicit
+    ``--grad-refit-dense-until 0`` -- the slow full-refit reference -- does NOT freeze
+    and remains subject to the skip. (Mirrors that bouquet default; keep in sync.)"""
+    return _flag_int(extra_args, "--grad-refit-dense-until") != 0
 
 
 def load_molecules(
@@ -227,6 +358,46 @@ def load_done_keys(output_path: Path) -> set:
     return done
 
 
+def drop_failed(output_path: Path, traj_path: Path) -> set:
+    """Remove every failed (``success != 1``) trial from the summary CSV and purge
+    its rows from the trajectory CSV. Returns the set of removed (config, name,
+    seed) keys so a ``--resume`` afterwards re-runs exactly those trials.
+
+    A clean-exit-but-unparsed trial can leave trajectory rows while still being
+    recorded ``success=0``; purging them prevents duplicate trajectory rows when
+    the retry succeeds.
+    """
+    if not output_path.exists():
+        return set()
+    with open(output_path, newline="") as f:
+        rows = list(csv.DictReader(f))
+    failed = {
+        (r["config"], r["name"], str(r["seed"]))
+        for r in rows if str(r.get("success")) != "1"
+    }
+    if not failed:
+        return failed
+
+    kept = [r for r in rows
+            if (r["config"], r["name"], str(r["seed"])) not in failed]
+    with open(output_path, "w", newline="") as f:
+        w = csv.DictWriter(f, fieldnames=FIELDNAMES)
+        w.writeheader()
+        w.writerows(kept)
+
+    if traj_path.exists():
+        with open(traj_path, newline="") as f:
+            trows = list(csv.DictReader(f))
+        tkept = [r for r in trows
+                 if (r["config"], r["name"], str(r["seed"])) not in failed]
+        if len(tkept) != len(trows):
+            with open(traj_path, "w", newline="") as f:
+                w = csv.DictWriter(f, fieldnames=TRAJ_FIELDNAMES)
+                w.writeheader()
+                w.writerows(tkept)
+    return failed
+
+
 def run_sweep(args: argparse.Namespace, configurations: Dict[str, List[str]]) -> None:
     """Run every (config, molecule, seed) trial; append to summary + trajectory CSVs.
 
@@ -238,6 +409,16 @@ def run_sweep(args: argparse.Namespace, configurations: Dict[str, List[str]]) ->
         if c not in configurations:
             sys.exit(f"Unknown config '{c}'. Known: {', '.join(configurations)}")
 
+    # --use-gradients passthrough: turn on the gradient-enhanced GP for every arm
+    # (requires a single surface; see require_single_surface / bouquet.cli).
+    if getattr(args, "use_gradients", False):
+        require_single_surface(args.energy, args.optimizer)
+        configurations = {
+            label: a if "--use-gradients" in a else a + ["--use-gradients"]
+            for label, a in configurations.items()
+        }
+        print("Gradients ON for all arms (--use-gradients; freeze schedule by default).")
+
     mols = load_molecules(args.input, args.smiles_column, args.name_column)
     print(f"Loaded {len(mols)} molecules; seeds={seeds}; configs={configs}")
 
@@ -246,8 +427,17 @@ def run_sweep(args: argparse.Namespace, configurations: Dict[str, List[str]]) ->
         f"{args.output.stem}_traj{args.output.suffix or '.csv'}"
     )
 
+    # --retry-failed: strip prior failures from both CSVs so they re-run; everything
+    # successful is still skipped (it implies resume). Without it, --resume skips ALL
+    # recorded trials, failures included.
+    if getattr(args, "retry_failed", False):
+        removed = drop_failed(args.output, traj_path)
+        print(f"--retry-failed: removed {len(removed)} failed trial(s); they will be "
+              f"re-run, successful trials skipped.")
+
     # Build the full task list, then drop any already-done (resume).
-    done = load_done_keys(args.output) if args.resume else set()
+    done = load_done_keys(args.output) if (args.resume or
+                                           getattr(args, "retry_failed", False)) else set()
     if not args.output.exists():
         with open(args.output, "w", newline="") as f:
             csv.DictWriter(f, fieldnames=FIELDNAMES).writeheader()
@@ -255,13 +445,50 @@ def run_sweep(args: argparse.Namespace, configurations: Dict[str, List[str]]) ->
         with open(traj_path, "w", newline="") as f:
             csv.DictWriter(f, fieldnames=TRAJ_FIELDNAMES).writeheader()
 
+    # Predictive skip: drop any gradient arm whose gradient-GP phase would exceed
+    # this many BO steps for a molecule (its per-step cost grows steeply, so big
+    # molecules run for hours and time out). Estimated from dihedral count up front
+    # so we never pay the wall-clock to discover it. 0 disables.
+    skip_thresh = getattr(args, "skip_grad_above_steps", 0) or 0
+    budget_cache: Dict[str, Optional[int]] = {}
+    skipped = []
+
+    def predicted_skip(config: str, smiles: str, name: str) -> bool:
+        if skip_thresh <= 0:
+            return False
+        extra = configurations[config]
+        if "--use-gradients" not in extra:
+            return False
+        if arm_freezes_hypers(extra):  # the freeze schedule keeps it tractable
+            return False
+        if smiles not in budget_cache:
+            budget_cache[smiles] = predict_bo_budget(smiles)
+        budget = budget_cache[smiles]
+        if budget is None:  # couldn't predict -> don't skip, just run it
+            return False
+        gsteps = arm_gradient_steps(extra, budget)
+        if gsteps > skip_thresh:
+            skipped.append((config, name, gsteps, budget))
+            return True
+        return False
+
     tasks = []
     for config in configs:
         for smiles, name in mols:
+            if predicted_skip(config, smiles, name):
+                continue
             for seed in seeds:
                 if (config, name, str(seed)) in done:
                     continue
                 tasks.append((config, smiles, name, seed))
+
+    if skipped:
+        print(f"\nPredictively skipped {len(skipped)} (config, molecule) cell(s) "
+              f"with > {skip_thresh} gradient-GP steps (all seeds each):")
+        for config, name, gsteps, budget in skipped:
+            print(f"  SKIP {config:<16} {name:<20} "
+                  f"({gsteps} grad steps of {budget}-step budget)")
+        print()
 
     total = len(tasks)
     print(f"{total} trials to run ({len(done)} already done)"
@@ -272,11 +499,32 @@ def run_sweep(args: argparse.Namespace, configurations: Dict[str, List[str]]) ->
     write_lock = threading.Lock()
     counter = {"n": 0}
 
+    # A non-positive --timeout disables the per-trial kill.
+    timeout = args.timeout if getattr(args, "timeout", 0) and args.timeout > 0 else None
+
+    # Failed-trial logs land in <output stem>_failed/ by default; --no-fail-logs off.
+    fail_log_dir = None
+    if not getattr(args, "no_fail_logs", False):
+        fail_log_dir = args.fail_log_dir or args.output.with_name(
+            f"{args.output.stem}_failed"
+        )
+
+    # Pin BLAS threads to 1 for bit-reproducible runs (real common-random-number
+    # pairing) at the cost of speed. On by default; --no-single-thread opts out.
+    env = single_thread_env() if getattr(args, "single_thread", True) else None
+    if env is not None:
+        print("Single-threaded (OMP/MKL/OPENBLAS=1): runs are seed-reproducible for "
+              "clean paired comparison. Pass --no-single-thread for raw speed.")
+    else:
+        print("WARNING: --no-single-thread: multi-threaded BLAS is non-deterministic; "
+              "the paired comparison carries a ~0.02 eV run-to-run noise floor.")
+
     def submit(task):
         config, smiles, name, seed = task
         return run_one(
             config, configurations[config], smiles, name, seed,
-            args.energy, args.optimizer,
+            args.energy, args.optimizer, timeout=timeout, fail_log_dir=fail_log_dir,
+            env=env,
         )
 
     t0 = time.time()
@@ -303,8 +551,9 @@ def run_sweep(args: argparse.Namespace, configurations: Dict[str, List[str]]) ->
                 n = counter["n"]
             e = row.get("e_e0_unconstrained", "")
             bs = row.get("best_step", "")
+            tag = "" if row.get("success") else "  FAILED (crash/timeout)"
             print(f"[{n}/{total}] {row['config']:<16} {row['name']:<16} "
-                  f"seed={row['seed']:<7} best_step={bs} E-E0={e}")
+                  f"seed={row['seed']:<7} best_step={bs} E-E0={e}{tag}")
 
     prog = Path(sys.argv[0]).name
     print(f"\nDone in {time.time() - t0:.0f}s. Wrote {args.output} and {traj_path}")
@@ -409,7 +658,10 @@ def analyze(args: argparse.Namespace, baseline: str) -> None:
     # Every RNG is seeded from --seed (torch included), so arms sharing a seed share
     # their randomness. Differencing per (name, seed) cancels the shared BO noise
     # (common random numbers) and isolates the config effect -- far lower variance
-    # than pairing on best-of-seeds.
+    # than pairing on best-of-seeds. NOTE: CRN is only exact when runs are
+    # deterministic; under default multi-threaded BLAS there is a ~0.02 eV
+    # run-to-run noise floor (see the module docstring), so treat per-(name, seed)
+    # deltas below that as noise unless the sweep was run with --single-thread.
     if baseline not in dfp["config"].unique():
         print(f"\n(No '{baseline}' rows; skipping paired comparison.)")
         return
@@ -709,7 +961,12 @@ def _plot_trajectories(df, best_known, configs, baseline, plot_dir) -> None:
 # ---------------------------------------------------------------------------
 
 
-def add_run_args(parser, config_names, priors_default=PRIORS_FILE_DEFAULT) -> None:
+def add_run_args(parser, config_names, priors_default=PRIORS_FILE_DEFAULT,
+                 gradients_default=None) -> None:
+    """Shared 'run' arguments. ``gradients_default``: if not None, add a
+    --use-gradients/--no-use-gradients flag with that default; when set, every arm
+    gets --use-gradients appended (single-surface check enforced). Sweeps that vary
+    gradients per-arm (sweep_gradient) leave it None and manage their own arms."""
     parser.add_argument("--input", required=True, type=Path, help="CSV with smiles,name")
     parser.add_argument("--output", required=True, type=Path, help="Tidy output CSV")
     parser.add_argument("--traj-output", type=Path, default=None,
@@ -718,12 +975,58 @@ def add_run_args(parser, config_names, priors_default=PRIORS_FILE_DEFAULT) -> No
     parser.add_argument("--configs", default=None,
                         help=f"Comma-separated subset of: {', '.join(config_names)}")
     parser.add_argument("--priors-file", default=priors_default)
-    parser.add_argument("--energy", default=None, choices=ENERGY_CHOICES)
-    parser.add_argument("--optimizer", default=None, choices=ENERGY_CHOICES)
+    # Default both methods to gfnff: it is fast and, being a single surface, satisfies
+    # the gradient single-surface requirement (energy == optimizer under --relax), so
+    # gradients can be enabled across every arm.
+    parser.add_argument("--energy", default="gfnff", choices=ENERGY_CHOICES)
+    parser.add_argument("--optimizer", default="gfnff", choices=ENERGY_CHOICES)
     parser.add_argument("--smiles-column", default="smiles")
     parser.add_argument("--name-column", default="name")
     parser.add_argument("--workers", "-w", type=int, default=1)
-    parser.add_argument("--resume", action="store_true")
+    parser.add_argument("--timeout", type=float, default=1800.0,
+                        help="Per-trial wall-clock limit in seconds; a trial that "
+                        "exceeds it is killed and recorded as a failure (some large, "
+                        "flexible molecules never converge). 0 disables (default 1800).")
+    parser.add_argument("--resume", action="store_true",
+                        help="Skip (config, molecule, seed) trials already in the "
+                        "output CSV, successes and failures alike")
+    parser.add_argument("--retry-failed", action="store_true",
+                        help="Re-run only the trials previously recorded as failures: "
+                        "drop their rows from the summary + trajectory CSVs, then "
+                        "resume (successful trials are still skipped). Use after a "
+                        "sweep where some trials timed out or crashed.")
+    parser.add_argument("--fail-log-dir", type=Path, default=None,
+                        help="Directory for captured logs of FAILED trials "
+                        "(default: <output stem>_failed/). One file per trial; "
+                        "returncode 124 means it hit --timeout.")
+    parser.add_argument("--no-fail-logs", action="store_true",
+                        help="Do not save logs for failed trials")
+    parser.add_argument("--single-thread", action=argparse.BooleanOptionalAction,
+                        default=True,
+                        help="Pin BLAS/OpenMP to 1 thread per trial so each run is "
+                        "bit-reproducible from its seed (DEFAULT: on). Multi-threaded "
+                        "BLAS is non-deterministic and the chaotic BO search amplifies "
+                        "it (~0.02 eV run-to-run), which breaks the paired (CRN) "
+                        "comparison and inflates the noise floor. Pass "
+                        "--no-single-thread for raw speed when reproducibility isn't "
+                        "needed; recover throughput with more --workers.")
+    parser.add_argument("--skip-grad-above-steps", type=int, default=0,
+                        help="Predictively skip any --use-gradients arm whose "
+                        "gradient-GP phase would run more than this many BO steps "
+                        "for a molecule (estimated from its dihedral count and the "
+                        "--auto budget), instead of grinding to a timeout. The "
+                        "gradient GP's per-step cost grows steeply, so large "
+                        "molecules can run for hours. A --gradient-steps N cap "
+                        "counts only N, so capped arms (e.g. gradhybrid) stay in. "
+                        "0 (default) disables.")
+    if gradients_default is not None:
+        parser.add_argument("--use-gradients", action=argparse.BooleanOptionalAction,
+                            default=gradients_default,
+                            help="Append --use-gradients to every arm (gradient-enhanced "
+                            f"GP; freeze schedule by bouquet default). Default: "
+                            f"{'on' if gradients_default else 'off'}. Requires "
+                            "--energy == --optimizer (single surface); --no-use-gradients "
+                            "runs the value-only GP everywhere.")
     parser.add_argument("--dry-run", action="store_true",
                         help="Print the plan and trial count, then exit")
 

--- a/scripts/sweep_gradient.py
+++ b/scripts/sweep_gradient.py
@@ -1,0 +1,154 @@
+#!/usr/bin/env python
+"""
+Compare the gradient-enhanced GP surrogate against the value-only GP over a
+molecule set, holding the acquisition loop fixed.
+
+Three arms isolate the surrogate. The acquisition loop, init method, priors, and
+budget are identical; the only difference is whether each energy evaluation also
+contributes a projected torsion gradient (dE/dtheta) to the GP:
+
+  nograd      : value-only GP                      (current default)
+  grad        : --use-gradients                    (gradient GP, whole run, full
+                hyperparameter fit every step) -- per-step cost grows as
+                O((n*(1+d))^3), so this is intractable late on large molecules
+                (a reference; the predictive skip protects it).
+  gradhybrid  : --use-gradients --gradient-steps N (gradient GP for N steps, then
+                value-only) -- keeps the early gradient benefit at bounded cost.
+                Set N with --grad-switch-step (default 50).
+  gradfreeze  : --use-gradients --grad-refit-dense-until N -- gradient GP for the
+                whole run, but hyperparameters are cold-fit only for the first N
+                steps then FROZEN (later steps only re-condition). Keeps ALL
+                gradient data, stays tractable, validated quality-neutral vs grad.
+  gradcadence : gradfreeze + --grad-refit-every K -- additionally cold-refreshes the
+                frozen hyperparameters every K post-dense steps (tests whether
+                periodic refits beat a pure freeze, at extra cost). Both cadence/
+                freeze arms are left in by the predictive skip.
+
+The hypothesis behind gradient-enhanced BO is data efficiency: every evaluation
+carries dE/dtheta as well, so the surrogate should locate the minimum in fewer
+calls. The payoff is therefore expected EARLY -- the trajectory (anytime) view is
+the primary comparison; parity at full budget is unremarkable. This mirrors
+sweep_init.py; see scripts/gradient_benchmark.py for the standalone
+calls-to-minimum variant that drives the solver directly.
+
+Single-surface requirement: the sweep runs with ``--relax``, and --use-gradients
+with --relax requires --energy and --optimizer to be the SAME method (the torsion
+gradient is only dE*/dtheta at a constrained minimum of the energy calculator).
+This script therefore defaults both to ``gfnff`` and refuses a mismatched pair.
+
+Cost warning: the full ``grad`` arm runs the gradient GP for the whole budget, and
+its per-step cost grows ~O((n*(1+d))^3) -- on molecules above ~70 BO steps it runs
+for hours and hits the per-trial --timeout, wasting compute. Two defenses:
+  * compare ``nograd`` vs ``gradhybrid`` only (drop the doomed arm entirely):
+        ... run --configs nograd,gradhybrid ...
+  * keep ``grad`` where it's feasible but predictively skip it where it isn't:
+        ... --skip-grad-above-steps 70
+    (estimates each molecule's budget from its dihedral count and skips only the
+    arms whose gradient-GP phase would exceed the threshold; gradhybrid's capped
+    phase stays in). Both avoid grinding large molecules to a timeout.
+
+Three phases (shared machinery lives in sweep_common.py):
+
+  # 1. Run the sweep (writes a summary CSV + a per-evaluation trajectory CSV).
+  #    --skip-grad-above-steps keeps the full-grad arm from timing out on big mols:
+  python scripts/sweep_gradient.py run --input mols.csv --output sweep_grad.csv \
+      --seeds 1234,12345,3141,314159,42 --workers 8 --skip-grad-above-steps 70
+
+  # 2. Analyze (per-config summary + paired-by-(molecule, seed) vs the baseline):
+  python scripts/sweep_gradient.py analyze sweep_grad.csv
+
+  # 3. Trajectory (anytime curves: who is ahead at 25%/50%/... of the budget):
+  python scripts/sweep_gradient.py traj sweep_grad_traj.csv
+"""
+
+import argparse
+import sys
+from pathlib import Path
+
+# Shared sweep machinery (same directory).
+sys.path.insert(0, str(Path(__file__).resolve().parent))
+import sweep_common as sc  # noqa: E402
+
+CONFIG_NAMES = ["nograd", "grad", "gradhybrid", "gradfreeze", "gradcadence"]
+BASELINE_LABEL = "nograd"
+
+
+def build_configurations(switch_step: int, dense_until: int, cadence_stride: int) -> dict:
+    """Arm -> extra CLI args. Only the surrogate differs; init, priors, budget, and
+    energy/optimizer are shared:
+
+      nograd      : value-only GP.
+      grad        : gradient-enhanced GP for the whole run, full hyperparameter fit
+                    every step. Its per-step cost grows as O((n*(1+d))^3), so this
+                    is intractable late on large molecules (the reference, not a
+                    practical setting; the predictive skip protects it).
+      gradhybrid  : gradient GP for the first ``switch_step`` BO steps, then
+                    value-only -- keeps the early gradient benefit at bounded cost.
+      gradfreeze  : gradient GP for the whole run; hyperparameters are cold-fit for
+                    the first ``dense_until`` steps then FROZEN (later steps only
+                    re-condition -- one Cholesky instead of ~200). Keeps all gradient
+                    data, stays tractable, validated quality-neutral vs ``grad``.
+      gradcadence : like gradfreeze but cold-REFRESHES the frozen hyperparameters
+                    every ``cadence_stride`` post-dense steps -- tests whether
+                    periodic refits buy anything over a pure freeze (at extra cost,
+                    since late cold refits are expensive).
+    """
+    dense = ["--use-gradients", "--grad-refit-dense-until", str(dense_until)]
+    return {
+        "nograd": [],
+        # grad = the slow full-refit reference: dense=0 opts out of the default freeze.
+        "grad": ["--use-gradients", "--grad-refit-dense-until", "0"],
+        "gradhybrid": ["--use-gradients", "--gradient-steps", str(switch_step)],
+        "gradfreeze": dense,
+        "gradcadence": dense + ["--grad-refit-every", str(cadence_stride)],
+    }
+
+
+def run(args: argparse.Namespace) -> None:
+    """Default and validate the single-surface requirement, then sweep.
+
+    The gradient arms need energy == optimizer under ``--relax`` (sweep_common always
+    relaxes); both default to ``gfnff`` (see add_run_args), so refuse a mismatched
+    pair rather than letting every gradient trial crash.
+    """
+    sc.require_single_surface(args.energy, args.optimizer)
+    sc.run_sweep(args, build_configurations(
+        args.grad_switch_step, args.grad_refit_dense_until, args.grad_cadence_stride,
+    ))
+
+
+def main() -> None:
+    p = argparse.ArgumentParser(description=__doc__,
+                                formatter_class=argparse.RawDescriptionHelpFormatter)
+    sub = p.add_subparsers(dest="command", required=True)
+
+    r = sub.add_parser("run", help="Run the sweep")
+    sc.add_run_args(r, CONFIG_NAMES)
+    r.add_argument("--grad-switch-step", type=int, default=50,
+                   help="For the 'gradhybrid' arm: BO step at which to switch from "
+                   "the gradient-enhanced GP to the value-only GP (default 50). "
+                   "Molecules whose budget is below this never switch.")
+    r.add_argument("--grad-refit-dense-until", type=int, default=20,
+                   help="For the 'gradfreeze'/'gradcadence' arms: number of leading "
+                   "BO steps with a cold full hyperparameter fit before freezing "
+                   "(default 20, matching the bouquet default).")
+    r.add_argument("--grad-cadence-stride", type=int, default=10,
+                   help="For the 'gradcadence' arm only: cold-refresh the frozen "
+                   "hyperparameters every N post-dense steps (default 10). "
+                   "'gradfreeze' never refreshes.")
+    r.set_defaults(func=run)
+
+    a = sub.add_parser("analyze", help="Summarize a sweep CSV")
+    sc.add_analyze_args(a)
+    a.set_defaults(func=lambda a: sc.analyze(a, BASELINE_LABEL))
+
+    t = sub.add_parser("traj", help="Anytime best-energy-vs-budget curves + plots")
+    sc.add_traj_args(t)
+    t.set_defaults(func=lambda a: sc.trajectory(a, BASELINE_LABEL))
+
+    args = p.parse_args()
+    args.func(args)
+
+
+if __name__ == "__main__":
+    main()

--- a/scripts/sweep_init.py
+++ b/scripts/sweep_init.py
@@ -60,7 +60,7 @@ def main() -> None:
     sub = p.add_subparsers(dest="command", required=True)
 
     r = sub.add_parser("run", help="Run the sweep")
-    sc.add_run_args(r, CONFIG_NAMES)
+    sc.add_run_args(r, CONFIG_NAMES, gradients_default=True)
     r.set_defaults(func=lambda a: sc.run_sweep(a, build_configurations(a.priors_file)))
 
     a = sub.add_parser("analyze", help="Summarize a sweep CSV")

--- a/scripts/sweep_priors.py
+++ b/scripts/sweep_priors.py
@@ -74,7 +74,7 @@ def main() -> None:
     sub = p.add_subparsers(dest="command", required=True)
 
     r = sub.add_parser("run", help="Run the sweep")
-    sc.add_run_args(r, list(CONFIGURATIONS))
+    sc.add_run_args(r, list(CONFIGURATIONS), gradients_default=True)
     r.set_defaults(func=lambda a: sc.run_sweep(a, build_configurations(a.priors_file)))
 
     a = sub.add_parser("analyze", help="Summarize a sweep CSV")

--- a/tests/test_config.py
+++ b/tests/test_config.py
@@ -49,6 +49,11 @@ class TestConfiguration:
         assert config.num_threads == 4
         assert config.charge == 0
         assert config.multiplicity == 1
+        # Gradient GP defaults to the "gradfreeze" schedule (cold-fit 20 steps,
+        # then freeze); full refitting every step is the opt-out (dense=0).
+        assert config.gradient_steps == 0
+        assert config.grad_refit_dense_until == 20
+        assert config.grad_refit_every == 0
 
     def test_configuration_string_path_conversion(self, tmp_path):
         """Test that string paths are converted to Path objects."""

--- a/tests/test_solver_gradients.py
+++ b/tests/test_solver_gradients.py
@@ -73,6 +73,132 @@ def test_run_optimization_records_aligned_gradients(butane_calc):
     assert finite >= n - 1
 
 
+def test_gradient_steps_switches_to_value_only(butane_calc, monkeypatch):
+    """gradient_steps caps the gradient-enhanced GP to the first N BO steps; the
+    rest fall back to the value-only GP."""
+    atoms, _, dihedrals, calc = butane_calc
+    state = solver._setup_initial_state(
+        atoms, dihedrals, calc, calc, False, None, use_gradients=True
+    )
+    state.gradient_steps = 2
+    solver._evaluate_initial_guesses(
+        state, dihedrals, calc, calc, False, 3, 0, None, None
+    )
+
+    # Spy on the per-step use_gradients flag without paying for the real GP fit.
+    seen = []
+
+    def spy(*args, **kwargs):
+        seen.append(kwargs.get("use_gradients"))
+        return np.zeros(len(dihedrals))  # valid degrees; stays at a fixed point
+
+    monkeypatch.setattr(solver, "_select_next_points_botorch", spy)
+    solver._run_optimization_loop(state, 5, dihedrals, calc, calc, False, None)
+
+    assert seen == [True, True, False, False, False]
+
+
+def test_gradient_steps_zero_keeps_gradients_whole_run(butane_calc, monkeypatch):
+    """gradient_steps <= 0 (default) keeps the gradient GP for every BO step."""
+    atoms, _, dihedrals, calc = butane_calc
+    state = solver._setup_initial_state(
+        atoms, dihedrals, calc, calc, False, None, use_gradients=True
+    )
+    assert state.gradient_steps == 0  # dataclass default
+    solver._evaluate_initial_guesses(
+        state, dihedrals, calc, calc, False, 3, 0, None, None
+    )
+
+    seen = []
+
+    def spy(*args, **kwargs):
+        seen.append(kwargs.get("use_gradients"))
+        return np.zeros(len(dihedrals))
+
+    monkeypatch.setattr(solver, "_select_next_points_botorch", spy)
+    solver._run_optimization_loop(state, 4, dihedrals, calc, calc, False, None)
+
+    assert seen == [True, True, True, True]
+
+
+def _record_frozen(monkeypatch, dihedrals):
+    """Spy on _select_next_points_botorch, recording whether each step is a
+    condition-only update (gp_frozen_hypers set) vs. a cold fit (None). Emulates the
+    GP returning fitted hypers when the loop asks (cold-fit steps)."""
+    seen = []
+
+    def spy(*args, **kwargs):
+        seen.append(kwargs.get("gp_frozen_hypers") is not None)
+        out = kwargs.get("gp_hyper_out")
+        if out is not None:
+            out["hypers"] = {"dummy": torch.zeros(())}
+        return np.zeros(len(dihedrals))
+
+    monkeypatch.setattr(solver, "_select_next_points_botorch", spy)
+    return seen  # True = condition-only (frozen), False = cold fit
+
+
+def test_grad_refit_freeze_schedule(butane_calc, monkeypatch):
+    """Cold full fits during the dense phase, then condition-only updates on the
+    frozen hyperparameters. Cold fits never load hypers (warm-starting drifts them)."""
+    atoms, _, dihedrals, calc = butane_calc
+    state = solver._setup_initial_state(
+        atoms, dihedrals, calc, calc, False, None, use_gradients=True
+    )
+    state.grad_refit_dense_until = 3
+    state.grad_refit_every = 0  # freeze after the dense phase
+    solver._evaluate_initial_guesses(
+        state, dihedrals, calc, calc, False, 3, 0, None, None
+    )
+
+    frozen = _record_frozen(monkeypatch, dihedrals)
+    solver._run_optimization_loop(state, 6, dihedrals, calc, calc, False, None)
+
+    # steps 0,1,2: cold fits; steps 3-5: condition-only on the frozen hypers.
+    assert frozen == [False, False, False, True, True, True]
+    assert state.grad_gp_hypers is not None  # frozen after the dense phase
+
+
+def test_grad_refit_periodic_cold_refresh(butane_calc, monkeypatch):
+    """grad_refit_every > 0 cold-refreshes the frozen hypers on a stride, with
+    condition-only updates between."""
+    atoms, _, dihedrals, calc = butane_calc
+    state = solver._setup_initial_state(
+        atoms, dihedrals, calc, calc, False, None, use_gradients=True
+    )
+    state.grad_refit_dense_until = 3
+    state.grad_refit_every = 2
+    solver._evaluate_initial_guesses(
+        state, dihedrals, calc, calc, False, 3, 0, None, None
+    )
+
+    frozen = _record_frozen(monkeypatch, dihedrals)
+    solver._run_optimization_loop(state, 8, dihedrals, calc, calc, False, None)
+
+    # dense 0,1,2 cold; then cold refit when (step-3)%2==0 -> steps 3,5,7 cold,
+    # steps 4,6 condition-only on frozen hypers.
+    assert frozen == [False, False, False, False, True, False, True, False]
+
+
+def test_grad_refit_dense_zero_fits_every_step(butane_calc, monkeypatch):
+    """dense_until=0 (the explicit opt-out from the default freeze schedule) cold-fits
+    every step -- the slow full-gradient reference, never conditioning on frozen
+    hypers."""
+    atoms, _, dihedrals, calc = butane_calc
+    state = solver._setup_initial_state(
+        atoms, dihedrals, calc, calc, False, None, use_gradients=True
+    )
+    state.grad_refit_dense_until = 0  # opt out of the default (20-step) freeze
+    solver._evaluate_initial_guesses(
+        state, dihedrals, calc, calc, False, 3, 0, None, None
+    )
+
+    frozen = _record_frozen(monkeypatch, dihedrals)
+    solver._run_optimization_loop(state, 4, dihedrals, calc, calc, False, None)
+
+    assert frozen == [False, False, False, False]  # all cold fits
+
+
 def test_value_only_path_leaves_gradients_nan(butane_calc):
     """With use_gradients off, no gradients are computed (all NaN)."""
     atoms, _, dihedrals, calc = butane_calc


### PR DESCRIPTION
Default based on benchmarking is freezing GP hyperparam @20 steps Allows gradient-boosted acquisition in minutes even for large mols

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Gradient-enhanced Bayesian optimization scheduling: limit gradient usage to initial steps before switching to value-only acquisition
  * Gradient GP hyperparameter refit control: configure dense refitting phases and periodic refresh intervals

* **Chores**
  * Package renamed to `bouquet-mol` with added homepage URL
  * Updated build artifact ignores

<!-- end of auto-generated comment: release notes by coderabbit.ai -->